### PR TITLE
Adding map string parser and tests

### DIFF
--- a/src/lib/map_strings.js
+++ b/src/lib/map_strings.js
@@ -1,7 +1,36 @@
+const mecatolRexSystemTile = 18;
+
+/**
+ * Validates a map string and can be parsed.
+ * 
+ * The input format can be one of the following:
+ * - 7 16 23 (normal)
+ * - {4} 7 16 23 (use 4 instead of Mecatol as center)
+ * - 7 83b2
+ * 
+ * Delimiters can be either one comma with/or any amount of spaces
+ * Leading and trailing spacesare ignored
+ * @param {string} mapString A map string from tts or another compatible format
+ * @returns {boolean} true if the map string is valid and can be parsed, otherwise false
+ */
 const validate = function (mapString) {
     return /^\s*(?:\{\d+\})?(?:\s*,?\s*\d+(?:[abAB]\d)?)+\s*$/.test(mapString)
 }
 
+/**
+ * Parses a map string to an array of objects.
+ * If there is no center tile replacement Mecatol is inserted as the first element.
+ * 
+ * The input format can be one of the following:
+ * - 7 16 23 (normal)
+ * - {4} 7 16 23 (use 4 instead of Mecatol as center)
+ * - 7 83b2
+ * 
+ * Delimiters can be either one comma with/or any amount of spaces
+ * Leading and trailing spacesare ignored
+ * @param {string} mapString A map string from tts or another compatible format
+ * @returns {({ tile: number} | { tile: number, side: 'a'|'b', rotation: number }[])} A list of objects representing the parsed tiles
+ */
 const parse = function (mapString) {
     if (!validate(mapString)) {
         throw new Error('Invalid map string')
@@ -15,22 +44,44 @@ const parse = function (mapString) {
         return tile;
     })
 
-    if (!mapString.startsWith('{') && tiles[0].tile !== 18) {
-        tiles.unshift({ tile: 18 });
+    if (!mapString.startsWith('{') && tiles[0].tile !== mecatolRexSystemTile) {
+        tiles.unshift({ tile: mecatolRexSystemTile });
     }
     return tiles;
 }
 
+
+/**
+ * Formats an array of objects to a tts map string.
+ * If the first element is Mecatol it will be ignored else a replacement expression will be created.
+ * 
+ * The output format will be one of the following:
+ * - 7 16 23 (normal)
+ * - {4} 7 16 23 (use 4 instead of Mecatol as center)
+ * - 7 83b2
+ * @param {({ tile: number} | { tile: number, side: 'a'|'b', rotation: number }[])} mapTiles 
+ * @returns {string} A map string compatible with tts
+ */
 const format = function (mapTiles) {
     mapTiles = mapTiles.slice()
     const centerTile = mapTiles.shift();
     let centerTileString = '';
-    if (centerTile.tile != 18) {
+    if (centerTile.tile != mecatolRexSystemTile) {
         centerTileString = '{' + centerTile.tile + '} '
     }
     return centerTileString + mapTiles.map(tile => [tile.tile, tile.side, tile.rotation].join('')).join(' ')
 }
 
+/**
+ * Normalizes a tts map string or another compatible format to the default tts format.
+ * 
+ * The output format will be one of the following:
+ * - 7 16 23 (normal)
+ * - {4} 7 16 23 (use 4 instead of Mecatol as center)
+ * - 7 83b2
+ * @param {string} mapString A map string from tts or another compatible format
+ * @returns {string} A map string compatible with tts
+ */
 const normalize = function (mapString) {
     return format(parse(mapString))
 }

--- a/src/lib/map_strings.js
+++ b/src/lib/map_strings.js
@@ -1,4 +1,4 @@
-const mecatolRexSystemTile = 18;
+const MECATOL_REX_SYSTEM_TILE = 18;
 
 /**
  * Validates a map string and can be parsed.
@@ -44,8 +44,8 @@ const parse = function (mapString) {
         return tile;
     })
 
-    if (!mapString.startsWith('{') && tiles[0].tile !== mecatolRexSystemTile) {
-        tiles.unshift({ tile: mecatolRexSystemTile });
+    if (!mapString.startsWith('{') && tiles[0].tile !== MECATOL_REX_SYSTEM_TILE) {
+        tiles.unshift({ tile: MECATOL_REX_SYSTEM_TILE });
     }
     return tiles;
 }
@@ -66,7 +66,7 @@ const format = function (mapTiles) {
     mapTiles = mapTiles.slice()
     const centerTile = mapTiles.shift();
     let centerTileString = '';
-    if (centerTile.tile != mecatolRexSystemTile) {
+    if (centerTile.tile != MECATOL_REX_SYSTEM_TILE) {
         centerTileString = '{' + centerTile.tile + '} '
     }
     return centerTileString + mapTiles.map(tile => [tile.tile, tile.side, tile.rotation].join('')).join(' ')

--- a/src/lib/map_strings.js
+++ b/src/lib/map_strings.js
@@ -1,0 +1,43 @@
+const validate = function (mapString) {
+    return /^\s*(?:\{\d+\})?(?:\s*,?\s*\d+(?:[abAB]\d)?)+\s*$/.test(mapString)
+}
+
+const parse = function (mapString) {
+    if (!validate(mapString)) {
+        throw new Error('Invalid map string')
+    }
+    const tiles = Array.from(mapString.matchAll(/\{?(?<tile>\d+)\}?(?:(?<side>[abAB])(?<rotation>\d))?/g)).map(match => {
+        const tile = { tile: parseInt(match.groups.tile) }
+        if(match.groups.side) {
+            tile.side = match.groups.side.toLowerCase();
+            tile.rotation = parseInt(match.groups.rotation);
+        }
+        return tile;
+    })
+
+    if (!mapString.startsWith('{') && tiles[0].tile !== 18) {
+        tiles.unshift({ tile: 18 });
+    }
+    return tiles;
+}
+
+const format = function (mapTiles) {
+    mapTiles = mapTiles.slice()
+    const centerTile = mapTiles.shift();
+    let centerTileString = '';
+    if (centerTile.tile != 18) {
+        centerTileString = '{' + centerTile.tile + '} '
+    }
+    return centerTileString + mapTiles.map(tile => [tile.tile, tile.side, tile.rotation].join('')).join(' ')
+}
+
+const normalize = function (mapString) {
+    return format(parse(mapString))
+}
+
+module.exports = {
+    validate,
+    parse,
+    format,
+    normalize
+}

--- a/src/lib/map_strings.test.js
+++ b/src/lib/map_strings.test.js
@@ -1,0 +1,75 @@
+// the "it(string, function)" style works with mocha and jest frameworks
+const { validate, parse, format } = require('./map_strings')
+const assert = require('assert')
+
+// test validation
+it('validate with numeric only', () => {
+    assert.equal(validate('7 18 23'), true)
+})
+
+it('validate with custom home tile', () => {
+    assert.equal(validate('{4} 7 18 23'), true)
+})
+
+it('validate with side and rotation', () => {
+    assert.equal(validate('7 83b2'), true)
+})
+
+it('validate supports multiple and mixed delimiters', () => {
+    assert.deepEqual(validate('{4}   ,7   18,   23'), true)
+})
+
+it('validate supports upper or lower case side values', () => {
+    assert.equal(validate('7 83B2'), true)
+})
+
+it('validate does not support invalid map string', () => {
+    assert.notEqual(validate('7 83b2 75b'), true)
+})
+
+it('validate does not support invalid characters', () => {
+    assert.notEqual(validate('{4} ^  ,7 $  18,   23'), true)
+})
+
+
+// test parsing
+it('parse with numeric only', () => {
+    assert.deepEqual(parse('7 18 23'), [{ tile: 18 }, { tile: 7 }, { tile: 18 }, { tile: 23 }])
+})
+
+it('parse with custom home tile', () => {
+    assert.deepEqual(parse('{4} 7 18 23'), [{ tile: 4 }, { tile: 7 }, { tile: 18 }, { tile: 23 }])
+})
+
+it('parse with side and rotation', () => {
+    assert.deepEqual(parse('7 83b2'), [{ tile: 18 }, { tile: 7 }, { tile: 83, side: 'b', rotation: 2 }])
+})
+
+it('parse supports multiple and mixed delimiters', () => {
+    assert.deepEqual(parse('{4}   ,7   18,   23'), [{ tile: 4 }, { tile: 7 }, { tile: 18 }, { tile: 23 }])
+})
+
+it('validate supports upper or lower case side values', () => {
+    assert.deepEqual(parse('7 83B2'), [{ tile: 18 }, { tile: 7 }, { tile: 83, side: 'b', rotation: 2 }])
+})
+
+it('parse throws for invalid map string', () => {
+    assert.throws(() => parse('7 83b2 75b'))
+})
+
+it('parse throws for support invalid characters', () => {
+    assert.throws(() => parse('{4} ^  ,7 $  18,   23'))
+})
+
+// test formatting
+it('format with numeric only', () => {
+    assert.equal(format([{ tile: 18 }, { tile: 7 }, { tile: 18 }, { tile: 23 }]), '7 18 23')
+})
+
+it('format with custom home tile', () => {
+    assert.equal(format([{ tile: 4 }, { tile: 7 }, { tile: 18 }, { tile: 23 }]), '{4} 7 18 23')
+})
+
+it('format with side and rotation', () => {
+    assert.equal(format([{ tile: 18 }, { tile: 7 }, { tile: 83, side: 'b', rotation: 2 }]), '7 83b2')
+})


### PR DESCRIPTION
This PR is intended to resolve an open trello request:
["Parse map string"](https://trello.com/c/p3w9qoOe/38-parse-map-string)

It can be used to parse, validate, format and normalize TTS map strings.
It also supports commas and spaces as delimiters and does not care about leading or trailing spaces as well
(see tests for reference)

Validate:
Validates if the provided string can be parsed

Parse:
Returns a list of objects in this form: { tile, side, rotation } (as requested)

Format:
Formats the output from above in a compatible TTS string

Normalize:
Normalizes the provided map string by parsing and reformatting it
