### PR TITLE
rework mock

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -1,5 +1,5 @@
 const { globalEvents } = require("@tabletop-playground/api");
-const { TriggerableMulticastDelegate } = require('./lib/triggerable-multicast-delegate')
+const TriggerableMulticastDelegate = require('./lib/triggerable-multicast-delegate')
 
 // Create global events delegates BEFORE loading other global scripts.
 globalEvents.TI4 = {

--- a/src/global/patch-unit-bag.test.js
+++ b/src/global/patch-unit-bag.test.js
@@ -2,7 +2,7 @@ const {
     REJECT_REASON,
     getRejectReason
 } = require('./patch-unit-bag')
-const { MockGameObject } = require('../mock/mock-game-object')
+const { MockGameObject } = require('../mock/mock-api')
 const assert = require('assert')
 
 it('can accept unit', () => {

--- a/src/global/r-swap-split-combine.test.js
+++ b/src/global/r-swap-split-combine.test.js
@@ -1,7 +1,9 @@
 const assert = require('assert')
-const { MockGameObject } = require('../mock/mock-game-object')
-const { MockPlayer } = require('../mock/mock-player')
-const { Rotator } = require('../mock/mock-rotator')
+const {
+    MockGameObject,
+    MockPlayer,
+    MockRotator
+} = require('../mock/mock-api')
 const {
     isConsumable,
     applyRule,
@@ -16,7 +18,7 @@ const OBJ = {
     }),
     fighter_x1_faceDown : new MockGameObject({ 
         templateMetadata : 'token:base/fighter_1',
-        rotation : new Rotator(0, 0, -180)
+        rotation : new MockRotator(0, 0, -180)
     }),
     fighter : new MockGameObject({ 
         templateMetadata : 'unit:base/fighter',

--- a/src/lib/facing.test.js
+++ b/src/lib/facing.test.js
@@ -1,14 +1,13 @@
 const assert = require('assert')
-const { MockGameObject } = require('../mock/mock-game-object')
-const { Rotator } = require('../mock/mock-rotator')
+const { MockGameObject, MockRotator } = require('../wrapper/api')
 const { Facing } = require('./facing')
 
 const FACING_UP = new MockGameObject({
-    rotation : new Rotator(0, 0, 0)
+    rotation : new MockRotator(0, 0, 0)
 })
 
 const FACING_DOWN = new MockGameObject({
-    rotation : new Rotator(0, 0, -180)
+    rotation : new MockRotator(0, 0, -180)
 })
 
 it('up', () => {

--- a/src/lib/object-namespace.js
+++ b/src/lib/object-namespace.js
@@ -1,3 +1,5 @@
+const { Card } = require('../wrapper/api')
+
 /**
  * Test and parse GameObject.getTemplateMetadata() namespace.
  * Objects use a 'type:source/name' namespace, e.g.:
@@ -6,6 +8,8 @@
  * 
  * As convention call these "nsid" to distinguish from "guid",
  * "template id", etc to know this is the kind of string in hand.
+ * 
+ * See https://github.com/TI4-Online/TI4-TTPG/wiki/NSID-Namespace
  */
 class ObjectNamespace {
     /**
@@ -13,6 +17,13 @@ class ObjectNamespace {
      */
     constructor() {
         throw new Error('Static only')
+    }
+
+    static getNsid(obj) {
+        if (obj instanceof Card) {
+            return obj.getCardDetails().metadata
+        }
+        return obj.getTemplateMetadata()
     }
 
     /**
@@ -23,8 +34,8 @@ class ObjectNamespace {
      * @returns {boolean}
      */
     static isGenericType(obj, type) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith(type)
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith(type)
     }
     
     /**
@@ -34,8 +45,8 @@ class ObjectNamespace {
      * @returns {{ type : string, source : string, name : string}}
      */
     static parseGeneric(obj) {
-        const id = obj.getTemplateMetadata()
-        const m = id.match(/^([^:]+):([^/]+)\/(.+)$/)
+        const nsid = ObjectNamespace.getNsid(obj)
+        const m = nsid.match(/^([^:]+):([^/]+)\/(.+)$/)
         return m && { type : m[1], source : m[2], name : m[3] }
     }
 
@@ -53,8 +64,8 @@ class ObjectNamespace {
     }
 
     static isCard(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('card')    
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('card')
     }
 
     static parseCard(obj) {
@@ -66,8 +77,8 @@ class ObjectNamespace {
     }
 
     static isCommandToken(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('token.command')    
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('token.command')
     }
 
     static parseCommandToken(obj) {
@@ -79,8 +90,8 @@ class ObjectNamespace {
     }
 
     static isControlToken(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('token.control')    
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('token.control')
     }
 
     static parseControlToken(obj) {
@@ -92,8 +103,8 @@ class ObjectNamespace {
     }
 
     static isStrategyCard(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('tile.strategy')
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('tile.strategy')
     }
 
     static parseStrategyCard(obj) {
@@ -105,8 +116,8 @@ class ObjectNamespace {
     }
 
     static isSystemTile(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('tile.system')
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('tile.system')
     }
 
     static parseSystemTile(obj) {
@@ -118,8 +129,8 @@ class ObjectNamespace {
     }
 
     static isToken(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('token')
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('token')
     }
 
     static parseToken(obj) {
@@ -131,8 +142,8 @@ class ObjectNamespace {
     }
 
     static isUnit(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('unit')
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('unit')
     }
 
     static parseUnit(obj) {
@@ -144,8 +155,8 @@ class ObjectNamespace {
     }
 
     static isUnitBag(obj) {
-        const id = obj.getTemplateMetadata()
-        return id.startsWith('bag.unit')
+        const nsid = ObjectNamespace.getNsid(obj)
+        return nsid.startsWith('bag.unit')
     }
 
     static parseUnitBag(obj) {
@@ -157,6 +168,4 @@ class ObjectNamespace {
     }
 }
 
-module.exports = {
-    ObjectNamespace,
-}
+module.exports = { ObjectNamespace }

--- a/src/lib/object-namespace.test.js
+++ b/src/lib/object-namespace.test.js
@@ -1,7 +1,8 @@
 // the "it(string, function)" style works with mocha and jest frameworks
 const { ObjectNamespace } = require('./object-namespace')
 const assert = require('assert')
-const { MockGameObject } = require('../mock/mock-game-object')
+const MockCard = require('../mock/mock-card')
+const MockGameObject = require('../mock/mock-game-object')
 
 it('cannot construct', () => {
     assert.throws(() => { new ObjectNamespace() })
@@ -22,8 +23,8 @@ it('generic', () => {
 
 it('card', () => {
     const id = 'card.action:base/direct_hit.2'
-    const obj = new MockGameObject({ templateMetadata : id })
-    const not = new MockGameObject({ templateMetadata : 'not:not/not' })
+    const obj = new MockCard({ cardDetails : { metadata : id }})
+    const not = new MockCard({ templateMetadata : 'not:not/not' })
 
     const type = ObjectNamespace.getCardType('action')
     assert(ObjectNamespace.isGenericType(obj, type))

--- a/src/lib/polygon.js
+++ b/src/lib/polygon.js
@@ -174,4 +174,4 @@ class Polygon {
     }
 }
 
-module.exports.Polygon = Polygon
+module.exports = { Polygon }

--- a/src/lib/triggerable-multicast-delegate.js
+++ b/src/lib/triggerable-multicast-delegate.js
@@ -68,6 +68,4 @@ class TriggerableMulticastDelegate {
     }
 }
 
-module.exports = {
-    TriggerableMulticastDelegate
-}
+module.exports = TriggerableMulticastDelegate

--- a/src/lib/triggerable-multicast-delegate.test.js
+++ b/src/lib/triggerable-multicast-delegate.test.js
@@ -1,4 +1,4 @@
-const { TriggerableMulticastDelegate } = require('./triggerable-multicast-delegate')
+const TriggerableMulticastDelegate = require('./triggerable-multicast-delegate')
 const assert = require('assert')
 
 it('require', () => {

--- a/src/mock/mock-api.js
+++ b/src/mock/mock-api.js
@@ -1,0 +1,27 @@
+// Export under the mock names so tests can be explicit they are not using TTPG objects.
+Object.assign(module.exports, {
+    MockCard : require('./mock-card'),
+    MockGameObject : require('./mock-game-object'),
+    MockGameWorld : require('./mock-game-world'),
+    MockGlobalScriptingEvents : require('./mock-global-scripting-events'),
+    MockPlayer : require('./mock-player'),
+    MockRotator : require('./mock-rotator'),
+    MockVector : require('./mock-vector'),
+})
+
+// Export under the TTPG api names for unaware consumers.
+Object.assign(module.exports, {
+    Card : module.exports.MockCard,
+    GameObject : module.exports.MockGameObject,
+    GameWorld : module.exports.MockGameWorld,
+    GlobalScriptingEvents : module.exports.MockGlobalScriptingEvents,
+    Player : module.exports.MockPlayer,
+    Rotator : module.exports.MockRotator,
+    Vector : module.exports.MockVector,
+})
+
+// Create TTPG runtime objects.
+Object.assign(module.exports, {
+    world : new module.exports.GameWorld(),
+    globalEvents : new module.exports.GlobalScriptingEvents(),
+})

--- a/src/mock/mock-card-details.js
+++ b/src/mock/mock-card-details.js
@@ -1,0 +1,12 @@
+class CardDetails {
+    constructor(data) {
+        this.flipped = data && data.flipped || false
+        this.index = data && data.index || 0
+        this.metadata = data && data.metadata || ''
+        this.name = data && data.name || ''
+        this.templateId = data && data.templateId || ''
+        this.textureOverrideURL = data && data.textureOverrideURL || ''
+    }
+}
+
+module.exports = CardDetails

--- a/src/mock/mock-card.js
+++ b/src/mock/mock-card.js
@@ -1,0 +1,15 @@
+const GameObject = require('./mock-game-object')
+const MockCardDetails = require('./mock-card-details')
+
+class Card extends GameObject {
+    constructor(data) {
+        super(data)
+        this._cardDetails = data && data.cardDetails || new MockCardDetails()
+    }
+
+    getCardDetails() {
+        return this._cardDetails
+    }
+}
+
+module.exports = Card

--- a/src/mock/mock-game-object.js
+++ b/src/mock/mock-game-object.js
@@ -1,8 +1,8 @@
-const { TriggerableMulticastDelegate } = require('../lib/triggerable-multicast-delegate')
-const { Vector } = require('./mock-vector')
-const { Rotator } = require('./mock-rotator')
+const TriggerableMulticastDelegate = require('../lib/triggerable-multicast-delegate')
+const Vector = require('./mock-vector')
+const Rotator = require('./mock-rotator')
 
-class MockGameObject {
+class GameObject {
     constructor(data) {
         this._id = data && data.id || 'abcd'
         this._owningPlayerSlot = data && data.owningPlayerSlot || -1
@@ -51,7 +51,6 @@ class MockGameObject {
         this._primaryColor = value
     }
 
-
     getRotation() {
         return this._rotation
     }
@@ -69,7 +68,4 @@ class MockGameObject {
     }
 }
 
-module.exports = {
-    GameObject : MockGameObject,
-    MockGameObject
-}
+module.exports = GameObject

--- a/src/mock/mock-game-world.js
+++ b/src/mock/mock-game-world.js
@@ -1,13 +1,20 @@
-class MockGameWorld {
-    getExecutionReason() {
+class GameWorld {
+    constructor(data) {
+        this._allObjects = data ? data.allObjects : []
+    }
+
+    static getExecutionReason() {
         return 'ScriptReload'
     }
 
+    // TTPG exposes this both static and per-instance.
+    getExecutionReason() {
+        return GameWorld.getExecutionReason()
+    }
+
     getAllObjects() {
-        return []
+        return this._allObjects
     }
 }
 
-module.exports = {
-    world : new MockGameWorld()
-}
+module.exports = GameWorld

--- a/src/mock/mock-global-scripting-events.js
+++ b/src/mock/mock-global-scripting-events.js
@@ -1,6 +1,6 @@
-const { TriggerableMulticastDelegate } = require('../lib/triggerable-multicast-delegate')
+const TriggerableMulticastDelegate = require('../lib/triggerable-multicast-delegate')
 
-class MockGlobalEvents {
+class GlobalScriptingEvents {
     onChatMessage = new TriggerableMulticastDelegate()
     onDiceRolled = new TriggerableMulticastDelegate()
     onObjectCreated = new TriggerableMulticastDelegate()
@@ -14,6 +14,4 @@ class MockGlobalEvents {
     onTick = new TriggerableMulticastDelegate()
 }
 
-module.exports = {
-    globalEvents : new MockGlobalEvents()
-}
+module.exports = GlobalScriptingEvents

--- a/src/mock/mock-player.js
+++ b/src/mock/mock-player.js
@@ -1,4 +1,4 @@
-class MockPlayer {
+class Player {
     constructor(data) {
         this._playerColor = data && data.playerColor || '?'
         this._selectedObjects = data && data.selectedObjects || []
@@ -18,7 +18,4 @@ class MockPlayer {
     }
 }
 
-module.exports = {
-    Player : MockPlayer,
-    MockPlayer
-}
+module.exports = Player

--- a/src/mock/mock-rotator.js
+++ b/src/mock/mock-rotator.js
@@ -9,4 +9,4 @@
     }
 }
 
-module.exports.Rotator = Rotator
+module.exports = Rotator

--- a/src/mock/mock-vector.js
+++ b/src/mock/mock-vector.js
@@ -9,4 +9,4 @@ class Vector {
     }
 }
 
-module.exports.Vector = Vector
+module.exports = Vector

--- a/src/wrapper/api.js
+++ b/src/wrapper/api.js
@@ -3,9 +3,5 @@
 try {
     module.exports = require('@tabletop-playground/api')
 } catch {
-    Object.assign(module.exports, require('../mock/mock-game-world'))
-    Object.assign(module.exports, require('../mock/mock-global-scripting-events'))
-    Object.assign(module.exports, require('../mock/mock-player'))
-    Object.assign(module.exports, require('../mock/mock-rotator'))
-    Object.assign(module.exports, require('../mock/mock-vector'))
+    module.exports = require('../mock/mock-api')
 }


### PR DESCRIPTION
Rework the mock system so mock objects mirror the TTPG class names (so instanceof works).
Also fix object-namespace to get card metadata correctly (stored in obj.getCardDetails.metadata, not obj.getTemplateMetadata), with test case.