### PR TITLE
Facing w/ Card objects

### DIFF
--- a/src/lib/facing.js
+++ b/src/lib/facing.js
@@ -1,3 +1,5 @@
+const { Card } = require('../wrapper/api')
+
 /**
  * TTPG doesn't have GameObject.isFaceUp.
  */
@@ -10,9 +12,16 @@ class Facing {
     }
     
     static isFaceUp(obj) {
-        // roll is 0 for faceup, -180 when flipped.
-        const roll = obj.getRotation().roll % 360
-        return -90 < roll && roll < 90
+        // roll is 0 for faceup, -180 or 180 when flipped.
+        let roll = obj.getRotation().roll % 360  // [-360:360]
+        roll = (roll + 360) % 360  // [0:360]
+
+        // TTPG cards show the back on top when in the natural rotation.
+        if ((obj instanceof Card) && !obj.getCardDetails().flipped) {
+            roll = (roll + 180) % 360  // [0:360]
+        }
+
+        return roll < 90 || roll > 270
     }
 
     static isFaceDown(obj) {

--- a/src/lib/facing.test.js
+++ b/src/lib/facing.test.js
@@ -1,6 +1,12 @@
 const assert = require('assert')
-const { MockGameObject, MockRotator } = require('../wrapper/api')
 const { Facing } = require('./facing')
+const {
+    Card,
+    MockCard,
+    MockCardDetails,
+    MockGameObject,
+    MockRotator
+} = require('../wrapper/api')
 
 const FACING_UP = new MockGameObject({
     rotation : new MockRotator(0, 0, 0)
@@ -18,4 +24,21 @@ it('up', () => {
 it('down', () => {
     assert(Facing.isFaceDown(FACING_DOWN))
     assert(!Facing.isFaceDown(FACING_UP))
+})
+
+it('card (reverse)', () => {
+    const normalCard = new MockCard({
+        cardDetails : new MockCardDetails()
+    })
+    const flippedMetadataCard = new MockCard({
+        cardDetails : new MockCardDetails({ flipped : true })
+    })
+    assert(normalCard instanceof Card)
+    assert(!normalCard.getCardDetails().flipped)
+
+    // The natural rotation for a card is showing the back on top.
+    // Facing handles this, normal state is considered face down
+    // unless template metadata marked it as flipped style.
+    assert(Facing.isFaceDown(normalCard))
+    assert(Facing.isFaceUp(flippedMetadataCard))
 })

--- a/src/mock/mock-api.js
+++ b/src/mock/mock-api.js
@@ -1,6 +1,7 @@
 // Export under the mock names so tests can be explicit they are not using TTPG objects.
 Object.assign(module.exports, {
     MockCard : require('./mock-card'),
+    MockCardDetails : require('./mock-card-details'),
     MockGameObject : require('./mock-game-object'),
     MockGameWorld : require('./mock-game-world'),
     MockGlobalScriptingEvents : require('./mock-global-scripting-events'),
@@ -12,6 +13,7 @@ Object.assign(module.exports, {
 // Export under the TTPG api names for unaware consumers.
 Object.assign(module.exports, {
     Card : module.exports.MockCard,
+    CardDetails : module.exports.MockCardDetails,
     GameObject : module.exports.MockGameObject,
     GameWorld : module.exports.MockGameWorld,
     GlobalScriptingEvents : module.exports.MockGlobalScriptingEvents,

--- a/tooling/generators/cardsheets.js
+++ b/tooling/generators/cardsheets.js
@@ -705,7 +705,7 @@ async function writeDeckTemplate(deckData, cardSize, cardDataArray, layout, face
     }
 
     // Generate a deterministic guid.
-    const guid = crypto.createHash('sha256').update(outputFilename).digest('hex').substring(0,32)
+    const guid = crypto.createHash('sha256').update(outputFilename).digest('hex').substring(0,32).toUpperCase()
 
     const json = {
         "Type": "Card",


### PR DESCRIPTION
TTPG considers "back side on top" is face up wrt object rotation roll.  For the time being handle this internally to the Facing library, can back this out if/when getting deck metadata to handle it.