### PR TITLE
Add a `launch.json` for interactive debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // If this isn't working, make sure to run `world.startDebugMode()`
+            // in Tabletop Playground to enable the debugging port
+            "name": "Tabletop Playground Inspector",
+            "type": "node",
+            "protocol": "inspector",
+            "request": "attach",
+            "address": "localhost",
+            "port": 9229,
+            "sourceMaps": true
+        }
+    ]
+}


### PR DESCRIPTION
This script allows for attaching VSCode to a running instance of Tabletop playground. This allows the console to be visible inside of VSCode, and (in principle) for breakpoints & interactive debugging (though right now that's not working due to some weird ways that Tabletop Playground imports scripts)

https://tabletop-playground.com/knowledge-base/scripting-basics/