### PR TITLE
Don't use `locale` with `console.log`

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -2,7 +2,7 @@ const { globalEvents } = require("@tabletop-playground/api");
 const TriggerableMulticastDelegate = require("./lib/triggerable-multicast-delegate");
 const locale = require("./lib/locale");
 
-console.log(locale("ui.message.welcome"));
+console.log("Welcome to Twilight Imperium IV");
 
 // Create global events delegates BEFORE loading other global scripts.
 globalEvents.TI4 = {


### PR DESCRIPTION
As a general rule, `console.log` messages are primarily read by developers (rather than end users), which means that it's generally good practice to *not* localize logged content.