### PR TITLE
use "unitAbility" to link to a unit modifier rather than the modifier code inline.

### DIFF
--- a/src/lib/unit/auxdata.js
+++ b/src/lib/unit/auxdata.js
@@ -90,11 +90,16 @@ class AuxData {
             }
 
             // Register any per-unit modifiers in the overall modifiers list.
+            // TODO XXX any "opponent" modifiers need to know opponent plastic.
             for (const unitAttrs of aux.unitAttrsSet.values()) {
-                if (unitAttrs.rawUnitModifier) {
-                    aux.unitModifiers.push(
-                        new UnitModifier(unitAttrs.rawUnitModifier)
-                    );
+                if (unitAttrs.raw.unitAbility) {
+                    const unitModifier =
+                        UnitModifier.getUnitAbilityUnitModifier(
+                            unitAttrs.raw.unitAbility
+                        );
+                    if (unitModifier) {
+                        aux.unitModifiers.push(unitModifier);
+                    }
                 }
             }
 
@@ -113,11 +118,13 @@ class AuxData {
 
             // Add any faction modifiers.
             // TODO XXX LOOK UP FACTION BY PLAYER SLOT, ADD MODIFIERS TO AUX.FACTIONABILITIES!
-            const abilityModifiers =
-                UnitModifier.getFactionAbilityUnitModifiers(
-                    aux.factionAbilities
-                );
-            aux.unitModifiers.push(...abilityModifiers);
+            for (const factionAbility of []) {
+                const unitModifier =
+                    UnitModifier.getFactionAbilityUnitModifier(factionAbility);
+                if (unitModifier) {
+                    aux.unitModifiers.push(unitModifier);
+                }
+            }
 
             UnitModifier.sortPriorityOrder(aux.unitModifiers);
 

--- a/src/lib/unit/unit-attrs.data.js
+++ b/src/lib/unit/unit-attrs.data.js
@@ -430,26 +430,7 @@ module.exports = [
         upgradeLevel: 1,
         localeName: "unit.mech.aerie_sentinel",
         triggerNsid: "card.leader.mech.argent:pok/aerie_sentinel",
-        unitModifier: {
-            // Does not count against capacity when with a ship with capacity
-            localeName: "unit.mech.aerie_sentinel",
-            localeDescription: "unit_modifier.desc.aerie_sentinel",
-            owner: "self",
-            priority: "mutate",
-            applyAll: (unitAttrsSet, auxData) => {
-                let hasCapacity = false;
-                for (const unitAttrs of unitAttrsSet.values()) {
-                    if (unitAttrs.raw.capacity) {
-                        hasCapacity = true;
-                        break;
-                    }
-                }
-                if (hasCapacity) {
-                    const mechAttrs = unitAttrsSet.get("mech");
-                    delete mechAttrs.raw.requireCapacity;
-                }
-            },
-        },
+        unitAbility: "unit.mech.aerie_sentinel",
     },
     {
         unit: "mech",
@@ -501,27 +482,7 @@ module.exports = [
         upgradeLevel: 1,
         localeName: "unit.mech.iconoclast",
         triggerNsid: "card.leader.mech.naalu:base/iconoclast",
-        unitModifier: {
-            // "+2 mech COMBAT rolls if opponent has fragment",
-            isCombat: true,
-            localeName: "unit.mech.iconoclast",
-            localeDescription: "unit_modifier.desc.iconoclast",
-            owner: "self",
-            priority: "adjust",
-            triggerNsid: "card.leader.mech.naalu:pok/iconoclast",
-            applyAll: (unitAttrsSet, auxData) => {
-                let opponentHasFragment = false; // TODO XXX
-                if (opponentHasFragment) {
-                    const mechAttrs = unitAttrsSet.get("mech");
-                    if (mechAttrs.raw.spaceCombat) {
-                        mechAttrs.raw.spaceCombat.hit -= 2;
-                    }
-                    if (mechAttrs.raw.groundCombat) {
-                        mechAttrs.raw.groundCombat.hit -= 2;
-                    }
-                }
-            },
-        },
+        unitAbility: "unit.mech.iconoclast",
     },
     {
         unit: "mech",
@@ -543,49 +504,14 @@ module.exports = [
         upgradeLevel: 1,
         localeName: "unit.mech.moll_terminus",
         triggerNsid: "card.leader.mech.mentak:base/moll_terminus",
-        unitModifier: {
-            // Other's ground forces on planet cannot SUSTAIN DAMAGE
-            isCombat: true,
-            localeName: "unit.mech.moll_terminus",
-            localeDescription: "unit_modifier.desc.moll_terminus",
-            owner: "opponent",
-            priority: "mutate",
-            applyEach: (unitAttrs, auxData) => {
-                if (
-                    unitAttrs.raw.ground &&
-                    unitAttrs.raw.sustainDamage &&
-                    auxData.opponent.has("mech")
-                ) {
-                    delete unitAttrs.raw.sustainDamage;
-                }
-            },
-        },
+        unitAbility: "unit.mech.moll_terminus",
     },
     {
         unit: "mech",
         upgradeLevel: 1,
         localeName: "unit.mech.mordred",
         triggerNsid: "card.leader.mech.nekro:base/mordred",
-        unitModifier: {
-            // +2 mech COMBAT rolls if opponent has X/Y token
-            isCombat: true,
-            localeName: "unit.mech.mordred",
-            localeDescription: "unit_modifier.desc.mordred",
-            owner: "self",
-            priority: "adjust",
-            applyAll: (unitAttrsSet, auxData) => {
-                let opponentHasXYToken = false; // TODO XXX
-                if (opponentHasXYToken) {
-                    const mechAttrs = unitAttrsSet.get("mech");
-                    if (mechAttrs.raw.spaceCombat) {
-                        mechAttrs.raw.spaceCombat.hit -= 2;
-                    }
-                    if (mechAttrs.raw.groundCombat) {
-                        mechAttrs.raw.groundCombat.hit -= 2;
-                    }
-                }
-            },
-        },
+        unitAbility: "unit.mech.mordred",
     },
     {
         unit: "mech",
@@ -628,36 +554,7 @@ module.exports = [
         upgradeLevel: 1,
         localeName: "unit.mech.shield_paling",
         triggerNsid: "card.leader.mech.jolnar:base/shield_paling",
-        unitModifier: {
-            // Infantry on planet with mech are not FRAGILE
-            isCombat: true,
-            localeName: "unit.mech.shield_paling",
-            localeDescription: "unit_modifier.desc.shield_paling",
-            owner: "self",
-            priority: "adjust",
-            applyAll: (unitAttrsSet, auxData) => {
-                // Normally mech is paired with Jol-Nar + FRAGILE, but watch out for Franken!
-                let hasFragile = false;
-                for (const unitModifier of auxData.self.unitModifiers) {
-                    if (
-                        unitModifier.raw.localeName ==
-                        "unit_modifier.name.fragile"
-                    ) {
-                        hasFragile = true;
-                        break;
-                    }
-                }
-                // Do not attempt to suppress "fragile" application, just undo it.
-                const infantryAttrs = unitAttrsSet.get("infantry");
-                if (
-                    hasFragile &&
-                    auxData.self.has("mech") &&
-                    infantryAttrs.raw.groundCombat
-                ) {
-                    infantryAttrs.raw.groundCombat -= 1;
-                }
-            },
-        },
+        unitAbility: "unit.mech.shield_paling",
     },
     {
         unit: "mech",
@@ -722,26 +619,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.mahact:franken.pok/arvicon_rex",
         spaceCombat: { dice: 2, hit: 5 },
-        unitModifier: {
-            // +2 flagship COMBAT against opponent with no token in your fleet pool
-            isCombat: true,
-            localeName: "unit.flagship.arvicon_rex",
-            localeDescription: "unit_modifier.desc.arvicon_rex",
-            owner: "self",
-            priority: "adjust",
-            applyAll: (unitAttrsSet, auxData) => {
-                let opponentTokenInFleetPool = false; // TODO XXX
-                if (opponentTokenInFleetPool) {
-                    const flagshipAttrs = unitAttrsSet.get("flagship");
-                    if (flagshipAttrs.raw.spaceCombat) {
-                        flagshipAttrs.raw.spaceCombat.hit -= 2;
-                    }
-                    if (flagshipAttrs.raw.groundCombat) {
-                        flagshipAttrs.raw.groundCombat.hit -= 2;
-                    }
-                }
-            },
-        },
+        unitAbility: "unit.flagship.arvicon_rex",
     },
     {
         unit: "flagship",
@@ -750,23 +628,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.norr:franken.base/cmorran_norr",
         spaceCombat: { dice: 2, hit: 6 },
-        unitModifier: {
-            // +1 to all COMBAT rolls for other ships with the C'morran N'orr
-            isCombat: true,
-            localeName: "unit.flagship.cmorran_norr",
-            localeDescription: "unit_modifier.desc.cmorran_norr",
-            owner: "self",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (
-                    unitAttrs.raw.ship &&
-                    unitAttrs.raw.unit !== "flagship" &&
-                    unitAttrs.raw.spaceCombat
-                ) {
-                    unitAttrs.raw.spaceCombat.hit -= 1;
-                }
-            },
-        },
+        unitAbility: "unit.flagship.cmorran_norr",
     },
     {
         unit: "flagship",
@@ -791,19 +653,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.mentak:franken.base/fourth_moon",
         spaceCombat: { dice: 2, hit: 7 },
-        unitModifier: {
-            // Opponent's ships cannot use SUSTAIN DAMAGE
-            isCombat: true,
-            localeName: "unit.flagship.fourth_moon",
-            localeDescription: "unit_modifier.desc.fourth_moon",
-            owner: "opponent",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (unitAttrs.raw.ship && unitAttrs.raw.sustainDamage) {
-                    unitAttrs.raw.sustainDamage = false;
-                }
-            },
-        },
+        unitAbility: "unit.flagship.fourth_moon",
     },
     {
         unit: "flagship",
@@ -846,26 +696,7 @@ module.exports = [
             "card.technology.unit_upgrade.naalu:franken.base/matriarch",
         spaceCombat: { dice: 2, hit: 9 },
         capacity: 6,
-        unitModifier: {
-            // Fighters may participate in ground combat
-            isCombat: true,
-            localeName: "unit.flagship.matriarch",
-            localeDescription: "unit_modifier.desc.matriarch",
-            owner: "self",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (
-                    unitAttrs.raw.unit === "fighter" &&
-                    !unitAttrs.raw.groundCombat
-                ) {
-                    unitAttrs.raw.groundCombat = {
-                        dice: unitAttrs.raw.spaceCombat.dice,
-                        hit: unitAttrs.raw.spaceCombat.hit,
-                        anyPlanet: true,
-                    };
-                }
-            },
-        },
+        unitAbility: "unit.flagship.matriarch",
     },
     {
         unit: "flagship",
@@ -898,19 +729,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.argent:franken.pok/quetzecoatl",
         spaceCombat: { dice: 2, hit: 7 },
-        unitModifier: {
-            // Other players cannot use SPACE CANNON against your ships in this system
-            isCombat: true,
-            localeName: "unit.flagship.quetzecoatl",
-            localeDescription: "unit_modifier.desc.quetzecoatl",
-            owner: "opponent",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (unitAttrs.raw.spaceCannon) {
-                    delete unitAttrs.raw.spaceCannon;
-                }
-            },
-        },
+        unitAbility: "unit.flagship.quetzecoatl",
     },
     {
         unit: "flagship",
@@ -919,33 +738,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.winnu:franken.base/salai_sai_corian",
         spaceCombat: { dice: 1, hit: 7 },
-        unitModifier: {
-            // Rolls number of dice equal to number of opponent's non-fighter ships
-            isCombat: true,
-            localeName: "unit.flagship.salai_sai_corian",
-            localeDescription: "unit_modifier.desc.salai_sai_corian",
-            owner: "self",
-            priority: "adjust",
-            applyAll: (unitAttrsSet, auxData) => {
-                let nonFighterShipCount = 0;
-                // TODO XXX NazRhoka mech on planet vs space (count as ship)
-                for (const unitAttrs of auxData.opponent.unitAttrsSet.values()) {
-                    if (
-                        unitAttrs.raw.ship &&
-                        unitAttrs.raw.unit !== "fighter" &&
-                        auxData.opponent.has(unitAttrs.raw.unit)
-                    ) {
-                        nonFighterShipCount += auxData.opponent.count(
-                            unitAttrs.raw.unit
-                        );
-                    }
-                }
-                const flagshipAttrs = unitAttrsSet.get("flagship");
-                if (flagshipAttrs.raw.spaceCombat) {
-                    flagshipAttrs.raw.spaceCombat.dice = nonFighterShipCount;
-                }
-            },
-        },
+        unitAbility: "unit.flagship.salai_sai_corian",
     },
     {
         unit: "flagship",
@@ -963,26 +756,7 @@ module.exports = [
         triggerNsid:
             "card.technology.unit_upgrade.nekro:franken.base/the_alastor",
         spaceCombat: { dice: 2, hit: 9 },
-        unitModifier: {
-            // Ground forces may participate in space combat
-            isCombat: true,
-            localeName: "unit.flagship.the_alastor",
-            localeDescription: "unit_modifier.desc.the_alastor",
-            owner: "self",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (
-                    unitAttrs.raw.ground &&
-                    unitAttrs.raw.groundCombat &&
-                    !unitAttrs.raw.spaceCombat
-                ) {
-                    unitAttrs.raw.spaceCombat = {
-                        dice: unitAttrs.raw.groundCombat.dice,
-                        hit: unitAttrs.raw.groundCombat.hit,
-                    };
-                }
-            },
-        },
+        unitAbility: "unit.flagship.the_alastor",
     },
     {
         unit: "flagship",
@@ -1016,23 +790,7 @@ module.exports = [
             "card.technology.unit_upgrade.naazrokha:franken.pok/visz_el_vir",
         spaceCombat: { dice: 2, hit: 9 },
         capacity: 4,
-        unitModifier: {
-            // Your mechs in this system roll 1 additional die during combat
-            isCombat: true,
-            localeName: "unit.flagship.visz_el_vir",
-            localeDescription: "unit_modifier.desc.visz_el_vir",
-            owner: "self",
-            priority: "adjust",
-            applyEach: (unitAttrs, auxData) => {
-                if (
-                    unitAttrs.raw.unit === "mech" &&
-                    unitAttrs.raw.groundCombat
-                ) {
-                    unitAttrs.raw.groundCombat.extraDice =
-                        (unitAttrs.raw.groundCombat.extraDice || 0) + 1;
-                }
-            },
-        },
+        unitAbility: "unit.flagship.visz_el_vir",
     },
     {
         unit: "flagship",

--- a/src/lib/unit/unit-attrs.js
+++ b/src/lib/unit/unit-attrs.js
@@ -177,14 +177,6 @@ class UnitAttrs {
     }
 
     /**
-     * Get linked unit modifier, if any.
-     * Do not require unit-modifier.js to avoid a require loop.
-     */
-    get rawUnitModifier() {
-        return this._rawUnitModifier;
-    }
-
-    /**
      * Assert this UnitAttrs complies with the schema.
      *
      * @param {function} onError - optional, called with the error

--- a/src/lib/unit/unit-attrs.schema.js
+++ b/src/lib/unit/unit-attrs.schema.js
@@ -1,5 +1,4 @@
 const Ajv = require("ajv");
-const { UNIT_MODIFIER_SCHEMA_JSON } = require("./unit-modifier.schema");
 
 const UNIT_ATTRS_SCHEMA_JSON = {
     $id: "http://example.com/lib/unit/unit_attrs.json",
@@ -18,9 +17,7 @@ const UNIT_ATTRS_SCHEMA_JSON = {
         requireCapacity: { type: "boolean" },
 
         // Unit attrs can be unit modifiers, apply to all units in fight (e.g. flagship, homebrew)
-        unitModifier: {
-            $ref: "http://example.com/lib/unit/unit_modifier.json",
-        },
+        unitAbility: { type: "string" },
 
         // Unit abilities.
         sustainDamage: { type: "boolean" },
@@ -125,9 +122,9 @@ class UnitAttrsSchema {
             return true;
         }
         if (!_unitAttrsValidator) {
-            _unitAttrsValidator = new Ajv({ useDefaults: true })
-                .addSchema(UNIT_MODIFIER_SCHEMA_JSON)
-                .compile(UNIT_ATTRS_SCHEMA_JSON);
+            _unitAttrsValidator = new Ajv({ useDefaults: true }).compile(
+                UNIT_ATTRS_SCHEMA_JSON
+            );
         }
         if (!_unitAttrsValidator(unit)) {
             (onError ? onError : console.error)(_unitAttrsValidator.errors);

--- a/src/lib/unit/unit-attrs.schema.test.js
+++ b/src/lib/unit/unit-attrs.schema.test.js
@@ -65,26 +65,3 @@ it("apply default value to spaceCombat.dice", () => {
     assert(UnitAttrsSchema.validate(carrier));
     assert.equal(carrier.spaceCombat.dice, 1);
 });
-
-it("verify modifier included schema", () => {
-    const bad = {
-        unit: "-",
-        localeName: "-",
-        unitModifier: {
-            a: 1,
-        },
-    };
-    assert(!UnitAttrsSchema.validate(bad, (err) => {}));
-
-    const good = {
-        unit: "-",
-        localeName: "-",
-        unitModifier: {
-            localeName: "-",
-            localeDescription: "-",
-            owner: "self",
-            priority: "mutate",
-        },
-    };
-    assert(UnitAttrsSchema.validate(good));
-});

--- a/src/lib/unit/unit-attrs.test.js
+++ b/src/lib/unit/unit-attrs.test.js
@@ -2,10 +2,8 @@ const assert = require("assert");
 const locale = require("../locale");
 const { UnitAttrsSchema } = require("./unit-attrs.schema");
 const { UnitAttrs } = require("./unit-attrs");
-const { UnitAttrsSet } = require("./unit-attrs-set");
-const { UnitModifier } = require("./unit-modifier");
-const { AuxData } = require("./auxdata");
 const UNIT_ATTRS = require("./unit-attrs.data");
+const UNIT_MODIFIERS = require("./unit-modifier.data");
 const { world, MockCard, MockCardDetails } = require("../../mock/mock-api");
 
 function _getUnitUpgrade(unitName) {
@@ -44,17 +42,18 @@ it("UNIT_ATTRS locale", () => {
     }
 });
 
-it("UNIT_ATTRS unitModifiers", () => {
+it("UNIT_ATTRS unitAbility", () => {
+    const triggerUnitAbilitySet = new Set();
+    for (const rawModifier of UNIT_MODIFIERS) {
+        if (rawModifier.triggerUnitAbility) {
+            triggerUnitAbilitySet.add(rawModifier.triggerUnitAbility);
+        }
+    }
+    // Make sure all unit abilities match a registered unit modifier.
     for (const rawAttrs of UNIT_ATTRS) {
-        if (rawAttrs.unitModifier) {
-            const unitModifier = new UnitModifier(rawAttrs.unitModifier);
-            const unitAttrsSet = new UnitAttrsSet();
-            const auxData = { self: new AuxData(), opponent: new AuxData() };
-            for (const unit of UnitAttrs.getAllUnitTypes()) {
-                auxData.self.overrideCount(unit, 1);
-                auxData.opponent.overrideCount(unit, 1);
-            }
-            unitModifier.apply(unitAttrsSet, auxData);
+        assert(!rawAttrs.triggerUnitAbility); // units generate, modifiers are triggered
+        if (rawAttrs.unitAbility) {
+            assert(triggerUnitAbilitySet.has(rawAttrs.unitAbility));
         }
     }
 });

--- a/src/lib/unit/unit-modifier.schema.js
+++ b/src/lib/unit/unit-modifier.schema.js
@@ -9,6 +9,7 @@ const UNIT_MODIFIER_SCHEMA_JSON = {
         triggerNsid: { type: "string" }, // find in player area to apply this unit upgrade
         triggerNsids: { type: "array", items: { type: "string" } },
         triggerFactionAbility: { type: "string" },
+        triggerUnitAbility: { type: "string" },
         owner: { type: "string" }, // self, opponent, or any
         priority: { type: "string" }, // mutate, adjust, or choose
         toggleActive: { type: "boolean" },

--- a/src/lib/unit/unit-modifier.test.js
+++ b/src/lib/unit/unit-modifier.test.js
@@ -94,10 +94,9 @@ it("static getPlayerUnitModifiers", () => {
     assert.equal(result[0].raw.localeName, "unit_modifier.name.morale_boost");
 });
 
-it("static getFactionAbilityUnitModifiers", () => {
-    const result = UnitModifier.getFactionAbilityUnitModifiers(["fragile"]);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].raw.localeName, "unit_modifier.name.fragile");
+it("static getFactionAbilityUnitModifier", () => {
+    const result = UnitModifier.getFactionAbilityUnitModifier("fragile");
+    assert.equal(result.raw.localeName, "unit_modifier.name.fragile");
 });
 
 it("name/desc", () => {


### PR DESCRIPTION
clean up per-unit modifiers (e.g. flagship abilities).  instead of adding modifier code to unit, add a 'unitAbility' and register that in unit-modifiers.data.json the same way we do for faction abilities -- keeps all unit modifier code in the same place.