### PR TITLE
Clean up AuxData "combat state" setup and filling.  All unit modifiers more freedom to decide if they apply.

### DIFF
--- a/src/lib/combat/combat-roller.test.js
+++ b/src/lib/combat/combat-roller.test.js
@@ -1,18 +1,18 @@
 const assert = require("assert");
-const { AuxData } = require("../unit/auxdata");
+const { AuxDataBuilder } = require("../unit/auxdata");
 const { CombatRoller } = require("./combat-roller");
 const { UnitModifier } = require("../unit/unit-modifier");
 const { MockPlayer, MockVector } = require("../../wrapper/api");
 
 it("constructor", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     new CombatRoller(auxData, rollType, player);
 });
 
 it("getModifierReport empty", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     const combatRoller = new CombatRoller(auxData, rollType, player);
@@ -21,7 +21,7 @@ it("getModifierReport empty", () => {
 });
 
 it("getModifierReport", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     auxData.unitModifiers.push(
@@ -32,7 +32,7 @@ it("getModifierReport", () => {
     assert.equal(report, "Roll modifier: Fragile (-1 to all COMBAT rolls)");
 });
 it("getRollReport", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     auxData.overrideCount("destroyer", 2);
@@ -48,7 +48,7 @@ it("getRollReport", () => {
 });
 
 it("getUnitToDiceCount", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     auxData.overrideCount("destroyer", 2);
@@ -58,7 +58,7 @@ it("getUnitToDiceCount", () => {
 });
 
 it("spawnDice", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     auxData.overrideCount("destroyer", 2);
@@ -69,7 +69,7 @@ it("spawnDice", () => {
 });
 
 it("roll", () => {
-    const auxData = new AuxData(-1);
+    const auxData = new AuxDataBuilder().build();
     const rollType = "antiFighterBarrage";
     const player = new MockPlayer();
     auxData.overrideCount("destroyer", 2);

--- a/src/lib/unit/auxdata-pair.js
+++ b/src/lib/unit/auxdata-pair.js
@@ -5,10 +5,10 @@ const { Broadcast } = require("../broadcast");
 const { Hex } = require("../hex");
 const { ObjectNamespace } = require("../object-namespace");
 const { UnitAttrs } = require("./unit-attrs");
+const { UnitAttrsSet } = require("./unit-attrs-set");
 const { UnitModifier } = require("./unit-modifier");
 const { UnitPlastic } = require("./unit-plastic");
 const { world } = require("../../wrapper/api");
-const { UnitAttrsSet } = require("./unit-attrs-set");
 
 /**
  * Given a combat between two players, create and fill in the AuxData
@@ -29,41 +29,29 @@ const { UnitAttrsSet } = require("./unit-attrs-set");
  */
 class AuxDataPair {
     /**
-     * Get the AuxData objects for a combat between two players.
+     * Fill in AuxData objects for a combat between two players.
      *
-     * @param {number} playerSlot1
-     * @param {number} playerSlot2 - may be -1 to identify opponent based on plastic
-     * @param {string} hex
-     * @param {string} planetLocaleName - omit for non-planet combat
-     * @param {Array.{UnitModifier}} extraPlayer1Modifiers
+     * Adjancy calculations use auxData1.hex.
+     * Planet assigment uses auxData1.planet.
+     *
+     * @param {AuxData} auxData1
+     * @param {AuxData} auxData2 - may be -1 to identify opponent based on plastic
      */
-    constructor(
-        playerSlot1,
-        playerSlot2,
-        hex,
-        planetLocaleName,
-        extraPlayer1Modifiers
-    ) {
-        assert(typeof playerSlot1 === "number");
-        assert(typeof playerSlot2 === "number");
-        assert(!hex || typeof hex === "string");
-        assert(!planetLocaleName || typeof planetLocaleName === "string");
-        assert(Array.isArray(extraPlayer1Modifiers));
+    constructor(auxData1, auxData2) {
+        assert(auxData1 instanceof AuxData);
+        assert(auxData2 instanceof AuxData);
 
-        this._playerSlot1 = playerSlot1;
-        this._playerSlot2 = playerSlot2;
-        this._hex = hex;
-        this._planet = planetLocaleName;
-        this._extraPlayer1Modifiers = extraPlayer1Modifiers;
+        this._aux1 = auxData1;
+        this._aux2 = auxData2;
 
+        this._aux1.setOpponent(this._aux2);
+
+        this._hex = this._aux1.hex;
+        this._planet = this._aux1.planet;
         this._adjHexes = new Set();
-
         this._allPlastic = false;
         this._hexPlastic = false;
         this._adjPlastic = false;
-
-        this._aux1 = false;
-        this._aux2 = false;
     }
 
     _getProcessQueue() {
@@ -76,9 +64,6 @@ class AuxDataPair {
             },
             () => {
                 this.computeOpponent();
-                this._aux1 = new AuxData(this._playerSlot1);
-                this._aux2 = new AuxData(this._playerSlot2);
-                this._aux1.unitModifiers.push(...this._extraPlayer1Modifiers);
             },
             () => {
                 this.computeSelfUnitCounts(this._aux1);
@@ -120,24 +105,21 @@ class AuxDataPair {
     }
 
     /**
-     * Get the two AuxData objects.
-     *
-     * @returns {Array.{AuxData, AuxData}}
+     * Fill in the two AuxData objects.
      */
-    getPairSync() {
+    fillPairSync() {
         const processQueue = this._getProcessQueue();
         for (const processEntry of processQueue) {
             processEntry();
         }
-        return [this._aux1, this._aux2];
     }
 
     /**
-     * Get the two AuxData objects.
+     * Fill in the two AuxData objects.
      *
      * @param {function} callback - (AuxData, AuxData) args
      */
-    getPairAsync(callback) {
+    fillPairAsync(callback) {
         const processQueue = this._getProcessQueue();
         const processNext = () => {
             const processEntry = processQueue.shift();
@@ -197,9 +179,11 @@ class AuxDataPair {
 
         if (this._planet) {
             // If using a planet, get units on and ships above planet.
-            UnitPlastic.assignPlanets(this._planet);
+            UnitPlastic.assignPlanets(this._hexPlastic);
             this._hexPlastic = this._hexPlastic.filter(
-                (plastic) => plastic.planet === this._planet
+                (plastic) =>
+                    plastic.planet &&
+                    plastic.planet.localeName === this._planet.localeName
             );
         }
     }
@@ -208,7 +192,7 @@ class AuxDataPair {
      * If no opponent was given compute one based on "not us" plastic in fight.
      */
     computeOpponent() {
-        if (this._playerSlot2 >= 0) {
+        if (this._aux2.playerSlot >= 0) {
             return; // already have an oppoent
         }
 
@@ -221,7 +205,7 @@ class AuxDataPair {
 
         // Prune down to other players' plastic.
         let otherPlastic = this._hexPlastic.filter(
-            (plastic) => plastic.owningPlayerSlot !== this._playerSlot1
+            (plastic) => plastic.owningPlayerSlot !== this._aux1.playerSlot
         );
 
         // If combat does not have a planet only consider ships.  Note there
@@ -238,15 +222,16 @@ class AuxDataPair {
 
         // Expect at most one other player's plastic, they are the opponent.
         for (const plastic of otherPlastic) {
-            if (plastic.owningPlayerSlot === this._playerSlot2) {
+            if (plastic.owningPlayerSlot === this._aux2.playerSlot) {
                 continue; // ignore if we already think this is opponent
             }
-            if (this._playerSlot2 < 0) {
-                this._playerSlot2 = plastic.owningPlayerSlot;
+            if (this._aux2.playerSlot < 0) {
+                // First opponent found, use it.
+                this._aux2.overridePlayerSlot(plastic.owningPlayerSlot);
             } else {
-                // Multiple opponents!
+                // Different opponent found, not a legal board state!
                 Broadcast.broadcastAll(locale("ui.error.too_many_opponents"));
-                this._playerSlot2 = -1;
+                this._aux2.overridePlayerSlot(-1);
                 break;
             }
         }
@@ -259,11 +244,6 @@ class AuxDataPair {
      */
     computeSelfUnitCounts(selfAuxData) {
         assert(selfAuxData instanceof AuxData);
-
-        // Abort if anonymous AuxData.
-        if (selfAuxData.playerSlot < 0) {
-            return;
-        }
 
         // Get hex and adjacent plastic for this player.
         // Also get counts, beware of x3 tokens!
@@ -365,6 +345,11 @@ class AuxDataPair {
         );
         selfAuxData.unitModifiers.push(...modifiersSelf);
         selfAuxData.unitModifiers.push(...modifiersOpponent);
+
+        // Get other modifiers that decide if they apply based on more
+        // information, such as nebula defense checks for nebula and defender.
+        const modifiersIf = UnitModifier.getTriggerIfUnitModifiers(selfAuxData);
+        selfAuxData.unitModifiers.push(...modifiersIf);
     }
 
     /**
@@ -411,10 +396,8 @@ class AuxDataPair {
         // Apply in mutate -> adjust -> choose order.
         UnitModifier.sortPriorityOrder(selfAuxData.unitModifiers);
         for (const unitModifier of selfAuxData.unitModifiers) {
-            unitModifier.apply(selfAuxData.unitAttrsSet, {
-                self: selfAuxData,
-                opponent: opponentAuxData,
-            });
+            console.log(`applying ${unitModifier.raw.localeName}`);
+            unitModifier.apply(selfAuxData.unitAttrsSet, selfAuxData);
         }
     }
 }

--- a/src/lib/unit/auxdata-pair.test.js
+++ b/src/lib/unit/auxdata-pair.test.js
@@ -7,6 +7,7 @@ const {
     MockVector,
     world,
 } = require("../../wrapper/api");
+const { AuxDataBuilder } = require("./auxdata");
 
 it("getPairSync", () => {
     const selfPlayerSlot = 7;
@@ -81,13 +82,12 @@ it("getPairSync", () => {
 
     let aux1, aux2;
     try {
-        [aux1, aux2] = new AuxDataPair(
-            selfPlayerSlot,
-            -1,
-            "<0,0,0>",
-            false,
-            []
-        ).getPairSync();
+        aux1 = new AuxDataBuilder()
+            .setPlayerSlot(selfPlayerSlot)
+            .setHex("<0,0,0>")
+            .build();
+        aux2 = new AuxDataBuilder().build();
+        new AuxDataPair(aux1, aux2).fillPairSync();
     } finally {
         for (const gameObject of world.getAllObjects()) {
             world.__removeObject(gameObject);
@@ -122,13 +122,12 @@ it("getPairSync", () => {
 
 it("unknown opponent", () => {
     const selfPlayerSlot = 7;
-    const [aux1, aux2] = new AuxDataPair(
-        selfPlayerSlot,
-        -1,
-        "<0,0,0>",
-        false,
-        []
-    ).getPairSync();
+    const aux1 = new AuxDataBuilder()
+        .setPlayerSlot(selfPlayerSlot)
+        .setHex("<0,0,0>")
+        .build();
+    const aux2 = new AuxDataBuilder().build();
+    new AuxDataPair(aux1, aux2).fillPairSync();
     assert.equal(aux1.playerSlot, selfPlayerSlot);
     assert.equal(aux2.playerSlot, -1);
 });
@@ -160,13 +159,12 @@ it("too many opponents", () => {
 
     let aux1, aux2;
     try {
-        [aux1, aux2] = new AuxDataPair(
-            selfPlayerSlot,
-            -1,
-            "<0,0,0>",
-            false,
-            []
-        ).getPairSync();
+        aux1 = new AuxDataBuilder()
+            .setPlayerSlot(selfPlayerSlot)
+            .setHex("<0,0,0>")
+            .build();
+        aux2 = new AuxDataBuilder().build();
+        new AuxDataPair(aux1, aux2).fillPairSync();
     } finally {
         for (const gameObject of world.getAllObjects()) {
             world.__removeObject(gameObject);

--- a/src/lib/unit/auxdata.js
+++ b/src/lib/unit/auxdata.js
@@ -1,21 +1,123 @@
 const assert = require("../../wrapper/assert-wrapper");
+const { System, Planet } = require("../system/system");
 const { UnitAttrsSet } = require("./unit-attrs-set");
+
+/**
+ * Builder interface to fill in base AuxData elements.
+ *
+ * Some things like unit attributes and modifiers are filled in by
+ * AuxDataPair (doing a table scan to find them).
+ */
+class AuxDataBuilder {
+    constructor() {
+        this._playerSlot = -1;
+        this._faction = false;
+        this._hex = false;
+        this._activatingPlayerSlot = -1;
+        this._activeSystem = false;
+        this._activePlanet = false;
+    }
+
+    /**
+     * Set player slot.
+     *
+     * @param {number} faction
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setPlayerSlot(playerSlot) {
+        assert(typeof playerSlot === "number");
+        this._playerSlot = playerSlot;
+        return this;
+    }
+
+    /**
+     * Set faction.
+     *
+     * @param {Faction} faction
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setFaction(faction) {
+        // TODO XXX
+        this._faction = faction;
+        return this;
+    }
+
+    /**
+     * Set hex.
+     *
+     * @param {string} hex
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setHex(hex) {
+        assert(typeof hex === "string");
+        this._hex = hex;
+        return this;
+    }
+
+    /**
+     * Set activating player slot.
+     *
+     * @param {number} activatingPlayerSlot
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setActivatingPlayerSlot(activatingPlayerSlot) {
+        assert(typeof activatingPlayerSlot === "number");
+        this._activatingPlayerSlot = activatingPlayerSlot;
+        return this;
+    }
+
+    /**
+     *
+     * @param {System} system
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setActiveSystem(system) {
+        assert(system instanceof System);
+        this._activeSystem = system;
+        return this;
+    }
+
+    /**
+     *
+     * @param {Planet} planet
+     * @returns {AuxDataBuilder} self for chaining
+     */
+    setActivePlanet(planet) {
+        assert(planet instanceof Planet);
+        this._activePlanet = planet;
+        return this;
+    }
+
+    /**
+     * Build AuxData.
+     *
+     * @returns {AuxData}
+     */
+    build() {
+        return new AuxData(this);
+    }
+}
 
 /**
  * Repository for per-player unit state.
  *
  * THIS IS THE INTERFACE TO UNIT DATA!
- *
- * Use `createForPair()` to get modified units involved in a combat.
  */
 class AuxData {
     /**
-     * Constructor.  Creates an empty but usable AuxData.
+     * Constructor.  Use AuxDataBuilder.build to create these.
      */
-    constructor(playerSlot) {
-        assert(typeof playerSlot === "number");
+    constructor(auxDataBuilder) {
+        assert(auxDataBuilder instanceof AuxDataBuilder);
 
-        this._playerSlot = playerSlot;
+        this._opponentAuxData = false;
+
+        this._playerSlot = auxDataBuilder._playerSlot;
+        this._faction = auxDataBuilder._faction;
+        this._hex = auxDataBuilder._hex;
+        this._activatingPlayerSlot = auxDataBuilder._activatingPlayerSlot;
+        this._activeSystem = auxDataBuilder._activeSystem;
+        this._activePlanet = auxDataBuilder._activePlanet;
 
         this._unitAttrsSet = new UnitAttrsSet();
         this._unitModifiers = []; // Array.{UnitModifier}
@@ -25,9 +127,125 @@ class AuxData {
 
         this._plastic = []; // Array.{UnitPlastic}
         this._adjacentPlastic = []; // Array.{UnitPlastic}
+    }
 
-        this._faction = undefined; // string NSID name ("letnev")
-        this._factionAbilities = []; // Array.{string} faction abilties
+    /**
+     * Should be constructior-time set, but opponent might not exist yet.
+     *
+     * @param {AuxData} auxData
+     * @returns {AuxData} self, for chaining
+     */
+    setOpponent(auxData) {
+        assert(auxData instanceof AuxData);
+        this._opponentAuxData = auxData;
+        return this;
+    }
+
+    /**
+     * For readability, modifers use 'auxData.self' and 'auxData.opponent'.
+     *
+     * @return {AuxData}
+     */
+    get self() {
+        return this;
+    }
+
+    /**
+     * For readability, modifers use 'auxData.self' and 'auxData.opponent'.
+     *
+     * @return {AuxData}
+     */
+    get opponent() {
+        return this._opponentAuxData;
+    }
+
+    /**
+     * Player slot.
+     *
+     * @returns {number} -1 if unknown
+     */
+    get playerSlot() {
+        return this._playerSlot;
+    }
+
+    /**
+     * Faction.
+     *
+     * @returns {Faction}
+     */
+    get faction() {
+        return this._faction;
+    }
+
+    /**
+     * Active hex.
+     *
+     * @returns {string}
+     */
+    get hex() {
+        return this._hex;
+    }
+
+    /**
+     * Which player(slot) activated the current system?
+     *
+     * @returns {number}
+     */
+    get activatingPlayerSlot() {
+        return this._activatingPlayerSlot;
+    }
+
+    /**
+     * Currently active system.
+     *
+     * @returns {System} may be false
+     */
+    get activeSystem() {
+        return this._activeSystem;
+    }
+    /**
+     * Currently active system.
+     *
+     * @returns {System} may be false
+     */
+    get activePlanet() {
+        return this._activePlanet;
+    }
+
+    /**
+     * Unit attributes.
+     *
+     * @returns {UnitAttrsSet}
+     */
+    get unitAttrsSet() {
+        return this._unitAttrsSet;
+    }
+
+    /**
+     * Unit modifiers.
+     *
+     * @returns {Array.{UnitModifier}}
+     */
+    get unitModifiers() {
+        return this._unitModifiers;
+    }
+
+    /**
+     * Units in main hex.
+     *
+     * @returns {Array.{UnitPlastic}}
+     */
+    get plastic() {
+        return this._plastic;
+    }
+
+    /**
+     * Units in adjacent hexes.
+     *
+     * @returns {Array.{UnitPlastic}}
+     */
+    get adjacentPlastic() {
+        return this._adjacentPlastic;
     }
 
     /**
@@ -75,15 +293,29 @@ class AuxData {
     }
 
     /**
+     * Replace the owning player slot.
+     *
+     * @param {number} playerSlot
+     * @returns {AuxData} self for chaining
+     */
+    overridePlayerSlot(playerSlot) {
+        assert(typeof playerSlot === "number");
+        this._playerSlot = playerSlot;
+        return this;
+    }
+
+    /**
      * Replace the unit count for main hex units.
      *
      * @param {string} unit
      * @param {number} value
+     * @returns {AuxData} self for chaining
      */
     overrideCount(unit, value) {
         assert(typeof unit === "string");
         assert(typeof value === "number");
         this._unitToCount[unit] = value;
+        return this;
     }
 
     /**
@@ -91,75 +323,14 @@ class AuxData {
      *
      * @param {string} unit
      * @param {number} value
+     * @returns {AuxData} self for chaining
      */
     overrideAdjacentCount(unit, value) {
         assert(typeof unit === "string");
         assert(typeof value === "number");
         this._unitToAdjacentCount[unit] = value;
-    }
-
-    /**
-     * Player slot.
-     *
-     * @returns {number} -1 if unknown
-     */
-    get playerSlot() {
-        return this._playerSlot;
-    }
-
-    /**
-     * Unit attributes.
-     *
-     * @returns {UnitAttrsSet}
-     */
-    get unitAttrsSet() {
-        return this._unitAttrsSet;
-    }
-
-    /**
-     * Unit modifiers.
-     *
-     * @returns {Array.{UnitModifier}}
-     */
-    get unitModifiers() {
-        return this._unitModifiers;
-    }
-
-    /**
-     * Units in main hex.
-     *
-     * @returns {Array.{UnitPlastic}}
-     */
-    get plastic() {
-        return this._plastic;
-    }
-
-    /**
-     * Units in adjacent hexes.
-     *
-     * @returns {Array.{UnitPlastic}}
-     */
-    get adjacentPlastic() {
-        return this._adjacentPlastic;
-    }
-
-    /**
-     * Faction NSID name.
-     *
-     * @returns {string}
-     */
-    get faction() {
-        return this._faction;
-    }
-
-    /**
-     * Faction abilities.
-     *
-     * @returns {Array.{string}}
-     */
-    get factionAbilities() {
-        return this._factionAbilities;
+        return this;
     }
 }
 
-module.exports = { AuxData };
+module.exports = { AuxDataBuilder, AuxData };

--- a/src/lib/unit/auxdata.test.js
+++ b/src/lib/unit/auxdata.test.js
@@ -1,7 +1,34 @@
 const assert = require("../../wrapper/assert-wrapper");
-const { AuxData } = require("./auxdata");
+const { AuxDataBuilder, AuxData } = require("./auxdata");
+const { System } = require("../system/system");
 
 it("constructor", () => {
-    const auxData = new AuxData(7);
-    assert.equal(auxData.playerSlot, 7);
+    const auxData = new AuxDataBuilder().build();
+    assert(auxData instanceof AuxData);
+});
+
+it("rich constructor", () => {
+    const playerSlot = 7;
+    const faction = {}; // TODO XXX
+    const hex = "<0,0,0>";
+    const activatingPlayerSlot = 8;
+    const activeSystem = System.getByTileNumber(18);
+    const activePlanet = activeSystem.planets[0];
+
+    const auxData = new AuxDataBuilder()
+        .setPlayerSlot(playerSlot)
+        .setFaction(faction)
+        .setHex(hex)
+        .setActivatingPlayerSlot(activatingPlayerSlot)
+        .setActiveSystem(activeSystem)
+        .setActivePlanet(activePlanet)
+        .build();
+    assert(auxData instanceof AuxData);
+
+    assert.equal(auxData.playerSlot, playerSlot);
+    assert.equal(auxData.faction, faction);
+    assert.equal(auxData.hex, hex);
+    assert.equal(auxData.activatingPlayerSlot, activatingPlayerSlot);
+    assert.equal(auxData.activeSystem, activeSystem);
+    assert.equal(auxData.activePlanet, activePlanet);
 });

--- a/src/lib/unit/unit-modifier.data.js
+++ b/src/lib/unit/unit-modifier.data.js
@@ -410,6 +410,14 @@ module.exports = [
         owner: "self",
         priority: "adjust",
         triggerNsid: "token:base/nebula_defense",
+        triggerIf: (auxData) => {
+            const isDefender =
+                auxData.self.playerSlot !== auxData.self.activatingPlayerSlot;
+            const isNebula =
+                auxData.self.activeSystem &&
+                auxData.self.activeSystem.anomalies.includes("nebula");
+            return isDefender && isNebula;
+        },
         applyEach: (unitAttrs, auxData) => {
             if (unitAttrs.raw.spaceCombat) {
                 unitAttrs.raw.spaceCombat.hit -= 1;
@@ -428,10 +436,14 @@ module.exports = [
             // Space cannon.
             let best = false;
             for (const unitAttrs of unitAttrsSet.values()) {
-                if (
-                    unitAttrs.raw.spaceCannon &&
-                    auxData.self.has(unitAttrs.raw.unit)
-                ) {
+                // Consider adjacent units if they have range.
+                let has = auxData.self.has(unitAttrs.raw.unit);
+                if (!has && auxData.self.hasAdjacent(unitAttrs.raw.unit)) {
+                    has =
+                        unitAttrs.raw.spaceCannon.range &&
+                        unitAttrs.raw.spaceCannon.range > 0;
+                }
+                if (unitAttrs.raw.spaceCannon && has) {
                     if (
                         !best ||
                         unitAttrs.raw.spaceCannon.hit < best.raw.spaceCannon.hit
@@ -663,10 +675,13 @@ module.exports = [
             // Space cannon.
             best = false;
             for (const unitAttrs of unitAttrsSet.values()) {
-                if (
-                    unitAttrs.raw.spaceCannon &&
-                    auxData.self.has(unitAttrs.raw.unit)
-                ) {
+                let has = auxData.self.has(unitAttrs.raw.unit);
+                if (!has && auxData.self.hasAdjacent(unitAttrs.raw.unit)) {
+                    has =
+                        unitAttrs.raw.spaceCannon.range &&
+                        unitAttrs.raw.spaceCannon.range > 0;
+                }
+                if (unitAttrs.raw.spaceCannon && has) {
                     if (
                         !best ||
                         unitAttrs.raw.spaceCannon.hit < best.raw.spaceCannon.hit
@@ -873,10 +888,13 @@ module.exports = [
             // Space cannon.
             best = false;
             for (const unitAttrs of unitAttrsSet.values()) {
-                if (
-                    unitAttrs.raw.spaceCannon &&
-                    auxData.self.has(unitAttrs.raw.unit)
-                ) {
+                let has = auxData.self.has(unitAttrs.raw.unit);
+                if (!has && auxData.self.hasAdjacent(unitAttrs.raw.unit)) {
+                    has =
+                        unitAttrs.raw.spaceCannon.range &&
+                        unitAttrs.raw.spaceCannon.range > 0;
+                }
+                if (unitAttrs.raw.spaceCannon && has) {
                     if (
                         !best ||
                         unitAttrs.raw.spaceCannon.hit < best.raw.spaceCannon.hit

--- a/src/lib/unit/unit-modifier.js
+++ b/src/lib/unit/unit-modifier.js
@@ -27,6 +27,7 @@ const OWNER = {
 let _triggerNsidToUnitModifier = false;
 let _factionAbilityToUnitModifier = false;
 let _unitAbilityToUnitModifier = false;
+let _triggerIfUnitModifiers = false;
 
 function _maybeInit() {
     if (_triggerNsidToUnitModifier) {
@@ -35,6 +36,7 @@ function _maybeInit() {
     _triggerNsidToUnitModifier = {};
     _factionAbilityToUnitModifier = {};
     _unitAbilityToUnitModifier = {};
+    _triggerIfUnitModifiers = [];
 
     for (const rawModifier of UNIT_MODIFIERS) {
         const unitModifier = new UnitModifier(rawModifier);
@@ -59,6 +61,10 @@ function _maybeInit() {
             const ability = rawModifier.triggerUnitAbility;
             assert(!_unitAbilityToUnitModifier[ability]);
             _unitAbilityToUnitModifier[ability] = unitModifier;
+        }
+
+        if (rawModifier.triggerIf) {
+            _triggerIfUnitModifiers.push(unitModifier);
         }
     }
 }
@@ -135,7 +141,22 @@ class UnitModifier {
             }
 
             // Found a unit modifier!  Add it to the list.
-            if (!unitModifiers.includes(unitModifier)) {
+            unitModifiers.push(unitModifier);
+        }
+        return unitModifiers;
+    }
+
+    /**
+     * In addition to "found an object" modifiers, let generic modifiers
+     * inspect state to see if they apply.
+     *
+     * @param {AuxData} auxData
+     * @returns {Array.{UnitModifier}}
+     */
+    static getTriggerIfUnitModifiers(auxData) {
+        const unitModifiers = [];
+        for (const unitModifier of _triggerIfUnitModifiers) {
+            if (unitModifier.raw.triggerIf(auxData)) {
                 unitModifiers.push(unitModifier);
             }
         }

--- a/src/lib/unit/unit-modifier.test.js
+++ b/src/lib/unit/unit-modifier.test.js
@@ -4,7 +4,7 @@ const { UnitModifierSchema } = require("./unit-modifier.schema");
 const { UnitModifier, PRIORITY, OWNER } = require("./unit-modifier");
 const { UnitAttrs } = require("./unit-attrs");
 const { UnitAttrsSet } = require("./unit-attrs-set");
-const { AuxData } = require("./auxdata");
+const { AuxDataBuilder } = require("./auxdata");
 const UNIT_MODIFIERS = require("./unit-modifier.data");
 const { world, MockCard, MockCardDetails } = require("../../mock/mock-api");
 
@@ -30,16 +30,28 @@ it("UNIT_MODIFIERS locale", () => {
     }
 });
 
+it("UNIT_MODIFIERS triggerIf", () => {
+    const auxData = new AuxDataBuilder().build();
+    for (const rawModifier of UNIT_MODIFIERS) {
+        if (rawModifier.triggerIf) {
+            rawModifier.triggerIf(auxData);
+        }
+    }
+});
+
 it("UNIT_MODIFIERS apply", () => {
     for (const rawModifier of UNIT_MODIFIERS) {
+        const aux1 = new AuxDataBuilder().build();
+        const aux2 = new AuxDataBuilder().build();
+        aux1.setOpponent(aux2);
+        aux2.setOpponent(aux1);
+        for (const unit of UnitAttrs.getAllUnitTypes()) {
+            aux1.overrideCount(unit, 1);
+            aux2.overrideCount(unit, 1);
+        }
         const unitModifier = new UnitModifier(rawModifier);
         const unitAttrsSet = new UnitAttrsSet();
-        const auxData = { self: new AuxData(-1), opponent: new AuxData(-1) };
-        for (const unit of UnitAttrs.getAllUnitTypes()) {
-            auxData.self.overrideCount(unit, 1);
-            auxData.opponent.overrideCount(unit, 1);
-        }
-        unitModifier.apply(unitAttrsSet, auxData);
+        unitModifier.apply(unitAttrsSet, aux1);
     }
 });
 

--- a/src/lib/unit/unit-plastic.js
+++ b/src/lib/unit/unit-plastic.js
@@ -66,6 +66,8 @@ class UnitPlastic {
      * @param {Array.<UnitPlastic>} unitPlastics
      */
     static assignTokens(unitPlastics) {
+        assert(Array.isArray(unitPlastics));
+
         const hexToOwnedArray = {};
         const hexToAnonArray = {};
         for (const unitPlastic of unitPlastics) {
@@ -111,6 +113,8 @@ class UnitPlastic {
      * @param {Array.<UnitPlastic>} unitPlastics
      */
     static assignPlanets(unitPlastics) {
+        assert(Array.isArray(unitPlastics));
+
         // TODO XXX
         throw new Error("not yet implemented");
     }
@@ -186,7 +190,7 @@ class UnitPlastic {
     /**
      * Unit is on this planet (after UnitPlastic.assignPlanets).
      *
-     * return {string|undefined}
+     * return {Planet|undefined}
      */
     get planet() {
         return this._planet;


### PR DESCRIPTION
simplify AuxData to have a builder to fill in some items, then pass to AuxDataPair to find units, modifiers, etc.  Let unit modifiers supply a triggerIf method to inspect combat before deciding if they apply (e.g. Nebula Defense)