### PR TITLE
Revert require specifying space cannon offense vs defense

### DIFF
--- a/src/lib/unit/unit-modifier.data.js
+++ b/src/lib/unit/unit-modifier.data.js
@@ -52,10 +52,7 @@ module.exports = [
         priority: "adjust",
         triggerNsid: "card.technology.blue:base/antimass_deflectors",
         filter: (auxData) => {
-            return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense"
-            );
+            return auxData.rollType === "spaceCannon";
         },
         applyEach: (unitAttrs, auxData) => {
             if (unitAttrs.raw.spaceCannon) {
@@ -496,8 +493,7 @@ module.exports = [
         triggerNsid: "card.technology.red:base/plasma_scoring",
         filter: (auxData) => {
             return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense" ||
+                auxData.rollType === "spaceCannon" ||
                 auxData.rollType === "bombardment"
             );
         },
@@ -598,7 +594,7 @@ module.exports = [
         priority: "adjust",
         triggerUnitAbility: "unit.flagship.quetzecoatl",
         filter: (auxData) => {
-            auxData.rollType === "spaceCannonOffense";
+            return auxData.rollType === "spaceCannon" && !auxData.activePlanet;
         },
         applyEach: (unitAttrs, auxData) => {
             if (unitAttrs.raw.spaceCannon) {
@@ -735,8 +731,7 @@ module.exports = [
         triggerNsid: "card.promissory.argent:pok/strike_wing_ambuscade",
         filter: (auxData) => {
             return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense" ||
+                auxData.rollType === "spaceCannon" ||
                 auxData.rollType === "antiFighterBarrage" ||
                 auxData.rollType === "bombardment"
             );
@@ -840,8 +835,7 @@ module.exports = [
         triggerNsid: "card.leader.commander.jolnar:pok/ta_zern",
         filter: (auxData) => {
             return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense" ||
+                auxData.rollType === "spaceCannon" ||
                 auxData.rollType === "antiFighterBarrage" ||
                 auxData.rollType === "bombardment"
             );
@@ -982,8 +976,7 @@ module.exports = [
         triggerNsid: "card.leader.commander.argent:pok/trrakan_aun_zulok",
         filter: (auxData) => {
             return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense" ||
+                auxData.rollType === "spaceCannon" ||
                 auxData.rollType === "antiFighterBarrage" ||
                 auxData.rollType === "bombardment"
             );
@@ -1062,10 +1055,7 @@ module.exports = [
         toggleActive: true,
         triggerNsid: "card.leader.hero.ul:pok/ul_the_progenitor",
         filter: (auxData) => {
-            return (
-                auxData.rollType === "spaceCannonOffense" ||
-                auxData.rollType === "spaceCannonDefense"
-            );
+            return auxData.rollType === "spaceCannon";
         },
         applyAll: (unitAttrsSet, auxData) => {
             if (auxData.self.has("space_dock")) {

--- a/src/objects/roller/auto-roller.js
+++ b/src/objects/roller/auto-roller.js
@@ -84,16 +84,18 @@ class AutoRoller {
         assert(!planet || planet instanceof Planet);
         assert(player instanceof Player);
 
-        // Some modifiers differentiate space cannon offense vs defense.
-        if (rollType === "spaceCannon") {
-            throw new Error(
-                'please specify "spaceCannonOffense" or "spaceCannonDefense"'
-            );
-        }
-
         if (!this._activeHex) {
             Broadcast.broadcastAll(locale("ui.error.no_active_system"));
             return;
+        }
+
+        // All space cannon rolls are spaceCannon.  Leave open the door to
+        // specify which type (defense can be inferred by active planet).
+        if (
+            rollType === "spaceCannonOffense" ||
+            rollType === "spaceCannonDefense"
+        ) {
+            rollType = "spaceCannon";
         }
 
         // Build self.
@@ -129,14 +131,6 @@ class AutoRoller {
             .build();
 
         new AuxDataPair(aux1, aux2).fillPairSync();
-
-        // At this point all space cannon rolls are spaceCannon.
-        if (
-            rollType === "spaceCannonOffense" ||
-            rollType === "spaceCannonDefense"
-        ) {
-            rollType = "spaceCannon";
-        }
 
         // COMBAT TIME!!
         const combatRoller = new CombatRoller(aux1, rollType, player);


### PR DESCRIPTION
Add unneeded complexity, can be inferred by if a planet is specified.