### PR TITLE
Attach mirage

### DIFF
--- a/assets/Templates/tokens/pok/EBEDE23C4130F50FD05C0BBBCF793B1C.json
+++ b/assets/Templates/tokens/pok/EBEDE23C4130F50FD05C0BBBCF793B1C.json
@@ -25,7 +25,7 @@
 	"Flippable": false,
 	"AutoStraighten": false,
 	"ShouldSnap": true,
-	"ScriptName": "",
+	"ScriptName": "objects/tokens/mirage.js",
 	"Blueprint": "",
 	"Models": [
 		{

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -10,7 +10,6 @@ const MIRAGE_ATTRS = {
     legendary: true,
     legendaryCard: "card.legendary_planet:pok/mirage_flight_academy",
 };
-const MIRAGE = new Planet(MIRAGE_ATTRS);
 let MIRAGE_SYSTEM = 0;
 
 function attachMirage(obj) {
@@ -27,14 +26,15 @@ function attachMirage(obj) {
         }
         if (system.planets.length === 0) {
             console.log("Attaching mirage to", system.tile);
-            system.planets.push(MIRAGE);
+            const mirage = new Planet(MIRAGE_ATTRS, system);
+            system.planets.push(mirage);
             const systemRot = systemObj.getRotation();
             const mirageRot = new Rotator(
                 systemRot.pitch,
                 systemRot.yaw - 100,
                 systemRot.roll
             );
-            obj.setPosition(systemObj.localPositionToWorld(MIRAGE.position));
+            obj.setPosition(systemObj.localPositionToWorld(mirage.position));
             obj.setRotation(mirageRot);
             obj.setScale(systemObj.getScale());
             obj.toggleLock();

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -56,11 +56,7 @@ function attachMirage(obj) {
 
         // shift the yaw so that the token text is upright in the system
         const systemRot = systemObj.getRotation();
-        const mirageRot = new Rotator(
-            systemRot.pitch,
-            systemRot.yaw - 110,
-            systemRot.roll
-        );
+        const mirageRot = systemRot.compose(new Rotator(0, -110, 0));
 
         // shift the position down slightly to account for the planet label
         const scale = systemObj.getScale();

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -21,7 +21,6 @@ function detachMirage() {
         const prevMirageSystem = System.getByTileNumber(
             _mirageSystemTileNumber
         );
-        console.log("Detaching mirage from", _mirageSystemTileNumber);
 
         // mirage only goes in 0 planet systems so removing the first
         // planet will remove mirage
@@ -49,7 +48,6 @@ function attachMirage(obj) {
         }
 
         // attach mirage to the system
-        console.log("Attaching mirage to", system.tile);
         const mirage = new Planet(MIRAGE_ATTRS, system);
         system.planets.push(mirage);
         _mirageSystemTileNumber = system.tile;

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -67,7 +67,10 @@ function attachMirage(obj) {
         );
         const miragePos = systemObj.localPositionToWorld(shiftedMiragePos);
 
-        obj.setPosition(miragePos);
+        // offset position in the z direction to ensure that the mirage is always
+        // on top of the system tile, otherwise it sometimes appears partially
+        // underneath the tile
+        obj.setPosition(miragePos.add(new Vector(0, 0, systemObj.getSize().z)));
         obj.setRotation(mirageRot);
         obj.setScale(scale);
 

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -74,9 +74,18 @@ function attachMirage(obj) {
         obj.setPosition(miragePos);
         obj.setRotation(mirageRot);
         obj.setScale(scale);
-        obj.toggleLock();
+
+        // convert to a "ground" object so that it cant be moved
+        // using toggleLock() causes the token to be unlocked when coming
+        // back from a script reload
+        obj.setObjectType(1);
     }
 }
 
 refObject.onReleased.add(attachMirage);
 refObject.onGrab.add(detachMirage);
+refObject.onCreated.add(attachMirage);
+
+if (world.getExecutionReason() === "ScriptReload") {
+    attachMirage(refObject);
+}

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -1,0 +1,48 @@
+const { refObject, Rotator } = require("../../wrapper/api");
+const { System, Planet } = require("../../lib/system/system");
+
+const MIRAGE_ATTRS = {
+    localeName: "planet.mirage",
+    resources: 1,
+    influence: 2,
+    trait: ["cultural"],
+    position: { x: 2, y: -1.25 },
+    legendary: true,
+    legendaryCard: "card.legendary_planet:pok/mirage_flight_academy",
+};
+const MIRAGE = new Planet(MIRAGE_ATTRS);
+let MIRAGE_SYSTEM = 0;
+
+function attachMirage(obj) {
+    const pos = obj.getPosition();
+    const systemObj = System.getSystemTileObjectByPosition(pos);
+    if (systemObj) {
+        const system = System.getBySystemTileObject(systemObj);
+        if (MIRAGE_SYSTEM) {
+            const prevMirageSystem = System.getByTileNumber(MIRAGE_SYSTEM);
+            console.log("Detaching mirage from", MIRAGE_SYSTEM);
+            // mirage can only go in 0 planet systems
+            prevMirageSystem.planets.splice(0, 1);
+            MIRAGE_SYSTEM = 0;
+        }
+        if (system.planets.length === 0) {
+            console.log("Attaching mirage to", system.tile);
+            system.planets.push(MIRAGE);
+            const systemRot = systemObj.getRotation();
+            const mirageRot = new Rotator(
+                systemRot.pitch,
+                systemRot.yaw - 100,
+                systemRot.roll
+            );
+            obj.setPosition(systemObj.localPositionToWorld(MIRAGE.position));
+            obj.setRotation(mirageRot);
+            obj.setScale(systemObj.getScale());
+            obj.toggleLock();
+            MIRAGE_SYSTEM = system.tile;
+        } else {
+            console.log("Mirage must be attached to a system with 0 planets");
+        }
+    }
+}
+
+refObject.onReleased.add(attachMirage);

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -1,5 +1,6 @@
 const { refObject, Rotator } = require("../../wrapper/api");
 const { System, Planet } = require("../../lib/system/system");
+const { Broadcast } = require("../../lib/broadcast");
 
 const MIRAGE_ATTRS = {
     localeName: "planet.mirage",
@@ -37,24 +38,30 @@ function attachMirage(obj) {
         detachMirage();
 
         const system = System.getBySystemTileObject(systemObj);
-        if (system.planets.length === 0) {
-            console.log("Attaching mirage to", system.tile);
-            const mirage = new Planet(MIRAGE_ATTRS, system);
-            system.planets.push(mirage);
-            const systemRot = systemObj.getRotation();
-            const mirageRot = new Rotator(
-                systemRot.pitch,
-                systemRot.yaw - 100,
-                systemRot.roll
+
+        // check that the system is a valid target for mirage
+        if (system.planets.length > 0) {
+            Broadcast.chatAll(
+                "Mirage must be attached to a system with 0 planets."
             );
-            obj.setPosition(systemObj.localPositionToWorld(mirage.position));
-            obj.setRotation(mirageRot);
-            obj.setScale(systemObj.getScale());
-            obj.toggleLock();
-            _mirageSystemTileNumber = system.tile;
-        } else {
-            console.log("Mirage must be attached to a system with 0 planets");
+            return;
         }
+
+        // attach mirage to the system
+        console.log("Attaching mirage to", system.tile);
+        const mirage = new Planet(MIRAGE_ATTRS, system);
+        system.planets.push(mirage);
+        const systemRot = systemObj.getRotation();
+        const mirageRot = new Rotator(
+            systemRot.pitch,
+            systemRot.yaw - 100,
+            systemRot.roll
+        );
+        obj.setPosition(systemObj.localPositionToWorld(mirage.position));
+        obj.setRotation(mirageRot);
+        obj.setScale(systemObj.getScale());
+        obj.toggleLock();
+        _mirageSystemTileNumber = system.tile;
     }
 }
 

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -10,19 +10,23 @@ const MIRAGE_ATTRS = {
     legendary: true,
     legendaryCard: "card.legendary_planet:pok/mirage_flight_academy",
 };
-let MIRAGE_SYSTEM = 0;
+
+// track the system mirage is in so we don't have to go searching for it
+let _mirageSystemTileNumber = 0;
 
 function attachMirage(obj) {
     const pos = obj.getPosition();
     const systemObj = System.getSystemTileObjectByPosition(pos);
     if (systemObj) {
         const system = System.getBySystemTileObject(systemObj);
-        if (MIRAGE_SYSTEM) {
-            const prevMirageSystem = System.getByTileNumber(MIRAGE_SYSTEM);
-            console.log("Detaching mirage from", MIRAGE_SYSTEM);
+        if (_mirageSystemTileNumber) {
+            const prevMirageSystem = System.getByTileNumber(
+                _mirageSystemTileNumber
+            );
+            console.log("Detaching mirage from", _mirageSystemTileNumber);
             // mirage can only go in 0 planet systems
             prevMirageSystem.planets.splice(0, 1);
-            MIRAGE_SYSTEM = 0;
+            _mirageSystemTileNumber = 0;
         }
         if (system.planets.length === 0) {
             console.log("Attaching mirage to", system.tile);
@@ -38,7 +42,7 @@ function attachMirage(obj) {
             obj.setRotation(mirageRot);
             obj.setScale(systemObj.getScale());
             obj.toggleLock();
-            MIRAGE_SYSTEM = system.tile;
+            _mirageSystemTileNumber = system.tile;
         } else {
             console.log("Mirage must be attached to a system with 0 planets");
         }

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -1,7 +1,6 @@
-const { refObject, Rotator } = require("../../wrapper/api");
+const { refObject, Rotator, Vector } = require("../../wrapper/api");
 const { System, Planet } = require("../../lib/system/system");
 const { Broadcast } = require("../../lib/broadcast");
-const Vector = require("../../mock/mock-vector");
 
 const MIRAGE_ATTRS = {
     localeName: "planet.mirage",

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -14,20 +14,29 @@ const MIRAGE_ATTRS = {
 // track the system mirage is in so we don't have to go searching for it
 let _mirageSystemTileNumber = 0;
 
+function detachMirage() {
+    if (_mirageSystemTileNumber) {
+        const prevMirageSystem = System.getByTileNumber(
+            _mirageSystemTileNumber
+        );
+        console.log("Detaching mirage from", _mirageSystemTileNumber);
+
+        // mirage only goes in 0 planet systems so removing the first
+        // planet will remove mirage
+        prevMirageSystem.planets.splice(0, 1);
+        _mirageSystemTileNumber = 0;
+    }
+}
+
 function attachMirage(obj) {
     const pos = obj.getPosition();
     const systemObj = System.getSystemTileObjectByPosition(pos);
     if (systemObj) {
+        // if mirage was already attached somewhere else, detach it first
+        // before attaching to the new system
+        detachMirage();
+
         const system = System.getBySystemTileObject(systemObj);
-        if (_mirageSystemTileNumber) {
-            const prevMirageSystem = System.getByTileNumber(
-                _mirageSystemTileNumber
-            );
-            console.log("Detaching mirage from", _mirageSystemTileNumber);
-            // mirage can only go in 0 planet systems
-            prevMirageSystem.planets.splice(0, 1);
-            _mirageSystemTileNumber = 0;
-        }
         if (system.planets.length === 0) {
             console.log("Attaching mirage to", system.tile);
             const mirage = new Planet(MIRAGE_ATTRS, system);
@@ -50,3 +59,4 @@ function attachMirage(obj) {
 }
 
 refObject.onReleased.add(attachMirage);
+refObject.onGrab.add(detachMirage);

--- a/src/objects/tokens/mirage.js
+++ b/src/objects/tokens/mirage.js
@@ -1,6 +1,7 @@
 const { refObject, Rotator } = require("../../wrapper/api");
 const { System, Planet } = require("../../lib/system/system");
 const { Broadcast } = require("../../lib/broadcast");
+const Vector = require("../../mock/mock-vector");
 
 const MIRAGE_ATTRS = {
     localeName: "planet.mirage",
@@ -8,6 +9,7 @@ const MIRAGE_ATTRS = {
     influence: 2,
     trait: ["cultural"],
     position: { x: 2, y: -1.25 },
+    radius: 1.75,
     legendary: true,
     legendaryCard: "card.legendary_planet:pok/mirage_flight_academy",
 };
@@ -51,17 +53,31 @@ function attachMirage(obj) {
         console.log("Attaching mirage to", system.tile);
         const mirage = new Planet(MIRAGE_ATTRS, system);
         system.planets.push(mirage);
+        _mirageSystemTileNumber = system.tile;
+
+        // place and lock the mirage token in the right location
+
+        // shift the yaw so that the token text is upright in the system
         const systemRot = systemObj.getRotation();
         const mirageRot = new Rotator(
             systemRot.pitch,
-            systemRot.yaw - 100,
+            systemRot.yaw - 110,
             systemRot.roll
         );
-        obj.setPosition(systemObj.localPositionToWorld(mirage.position));
+
+        // shift the position down slightly to account for the planet label
+        const scale = systemObj.getScale();
+        const shiftedMiragePos = new Vector(
+            mirage.position.x - 0.2 * scale.x,
+            mirage.position.y,
+            mirage.position.z
+        );
+        const miragePos = systemObj.localPositionToWorld(shiftedMiragePos);
+
+        obj.setPosition(miragePos);
         obj.setRotation(mirageRot);
-        obj.setScale(systemObj.getScale());
+        obj.setScale(scale);
         obj.toggleLock();
-        _mirageSystemTileNumber = system.tile;
     }
 }
 


### PR DESCRIPTION
Looking for input on whether or not this is the right way to go about attachments.

As long as the Planet object created for Mirage has a position (and the mirage token is placed at that position) the position-to-planet translation will work as expected. Currently, it places the Mirage token in the same position on the tile as the planet in a one planet + one wormhole system (e.g. Quann, tile 25).