### PR TITLE
Bug fixes

### DIFF
--- a/assets/Templates/tokens/base/09DF69524B6B7064D2CD6D8A0F7ADA59.json
+++ b/assets/Templates/tokens/base/09DF69524B6B7064D2CD6D8A0F7ADA59.json
@@ -2,7 +2,7 @@
 	"Type": "Generic",
 	"GUID": "09DF69524B6B7064D2CD6D8A0F7ADA59",
 	"Name": "Custodian token",
-	"Metadata": "token.naalu:base/zero",
+	"Metadata": "token:base/custodians",
 	"CollisionType": "Regular",
 	"Friction": 0.7,
 	"Restitution": 0.3,

--- a/lang/en.json
+++ b/lang/en.json
@@ -437,6 +437,7 @@
     "token.tradegood_commodity_3": "Tradegoods/Commodities x3",
     "bag.token": "{token} Supply",
     "bag.garbage": "Garbage",
+    "bag.exploration_tokens": "Exploration Tokens",
 
     "token.dimensional_tear": "Dimensional Tear",
     "token.frontier": "Frontier",

--- a/lang/en.json
+++ b/lang/en.json
@@ -427,6 +427,7 @@
     "bag.token.control": "Control Tokens",
 
     "token.speaker": "Speaker",
+    "token.custodians": "Custodians",
 
     "token.fighter_1": "Fighter x1",
     "token.fighter_3": "Fighter x3",

--- a/src/global/right-click-system.js
+++ b/src/global/right-click-system.js
@@ -29,6 +29,7 @@ function _closePopup() {
 
 function addRightClickOptions(systemTileObj) {
     assert(systemTileObj instanceof GameObject);
+    const system = world.TI4.getSystemBySystemTileObject(systemTileObj);
     const getNamesAndActions = () => {
         const namesAndActions = [
             {
@@ -38,14 +39,17 @@ function addRightClickOptions(systemTileObj) {
                     CommandToken.activateSystem(systemTileObj, player);
                 },
             },
-            {
+        ];
+        if (system.tile !== 18 && system.planets.length > 0) {
+            namesAndActions.push({
                 name: locale("ui.action.system.diplomacy"),
                 action: (player) => {
                     _closePopup();
                     CommandToken.diplomacySystem(systemTileObj, player);
                 },
-            },
-        ];
+            });
+        }
+
         const exploreNamesAndActions =
             Explore.getExploreActionNamesAndActions(systemTileObj);
         for (const nameAndAction of exploreNamesAndActions) {

--- a/src/lib/explore/explore.js
+++ b/src/lib/explore/explore.js
@@ -1,6 +1,7 @@
 const assert = require("../../wrapper/assert-wrapper");
 const locale = require("../locale");
 const PositionToPlanet = require("../system/position-to-planet");
+const { CardUtil } = require("../card/card-util");
 const { DealDiscard } = require("../card/deal-discard");
 const { ObjectNamespace } = require("../object-namespace");
 const { Spawn } = require("../../setup/spawn/spawn");
@@ -169,6 +170,18 @@ class Explore {
         if (tokenObj.__attachment) {
             // Script on object onCreated called during spawn
             tokenObj.__attachment.attach(planet, systemTileObj);
+        }
+
+        // Extra cards? (Mirage)
+        if (attachmentData.extraCardNsids) {
+            const cards = CardUtil.gatherCards((nsid) => {
+                return attachmentData.extraCardNsids.includes(nsid);
+            });
+            for (let i = 0; i < cards.length; i++) {
+                const card = cards[i];
+                card.setPosition(pos.add([0, 0, 1 + i]));
+                card.setRotation(rot);
+            }
         }
     }
 }

--- a/src/lib/map-string/map-string-load.js
+++ b/src/lib/map-string/map-string-load.js
@@ -75,7 +75,9 @@ class MapStringLoad {
         }
 
         // Add Mallice
-        placeTile({ tile: 82 }, "<-4,5,-1>");
+        if (world.TI4.config.pok) {
+            placeTile({ tile: 82 }, "<-4,5,-1>");
+        }
     }
 }
 

--- a/src/lib/phase/end-of-round.js
+++ b/src/lib/phase/end-of-round.js
@@ -256,6 +256,9 @@ class EndStatusPhase {
         }
 
         for (const obj of strategyCards) {
+            if (!FindTurnOrder.isStrategyCardPicked(obj)) {
+                continue; // already on (a) home spot, leave it alone
+            }
             const nsid = ObjectNamespace.getNsid(obj);
             const snapPoint = nsidToSnapPoint[nsid];
             assert(snapPoint);

--- a/src/lib/player-desk/player-desk-ui.js
+++ b/src/lib/player-desk/player-desk-ui.js
@@ -48,8 +48,8 @@ class PlayerDeskUI {
             );
         }
 
-        // AFTER SETUP + BEFORE READY: add/remove faction
-        if (config.canFaction && !config.isReady) {
+        // BEFORE READY + AFTER SETUP: add/remove faction
+        if (!config.isReady && config.canFaction) {
             if (config.hasFaction) {
                 panel.addChild(
                     this._createButton(
@@ -67,7 +67,8 @@ class PlayerDeskUI {
             }
         }
 
-        if (!config.isReady && config.hasFaction) {
+        // ALWAYS: ready
+        if (config.hasFaction) {
             panel.addChild(
                 this._createButton("ui.desk.done", this._callbacks.onReady)
             );

--- a/src/lib/player-desk/player-desk.js
+++ b/src/lib/player-desk/player-desk.js
@@ -178,6 +178,7 @@ globalEvents.TI4.onPlayerCountChanged.add((newPlayerCount, player) => {
         }
         playerDesk.addUI();
     }
+    PlayerDesk.resetUIs();
 });
 
 // Unseat host when first loading game.
@@ -344,17 +345,21 @@ class PlayerDesk {
     }
 
     addUI() {
-        // Do not apply UI once "ready".
-        if (this._ready) {
+        const playerSlot = this.playerSlot;
+        const isOccupied = world.getPlayerBySlot(playerSlot);
+        const isReady = this.isDeskReady();
+        // No UI once "ready" (unless not seated, show for "take seat")
+        if (isOccupied && isReady) {
             return;
         }
         const colorOptions = this.getColorOptions();
-        const playerSlot = this.playerSlot;
         const config = {
-            isReady: this.isDeskReady(),
-            isOccupied: world.getPlayerBySlot(playerSlot),
+            isReady,
+            isOccupied,
             canFaction: world.TI4.config.timestamp > 0,
-            hasFaction: world.TI4.getFactionByPlayerSlot(playerSlot),
+            hasFaction: world.TI4.getFactionByPlayerSlot(playerSlot)
+                ? true
+                : false,
         };
         assert(!this._ui);
         this._ui = new PlayerDeskUI(this, colorOptions, {

--- a/src/objects/attachments/attachment.data.js
+++ b/src/objects/attachments/attachment.data.js
@@ -75,6 +75,10 @@ const ATTACHMENTS = [
         localeName: "token.exploration.mirage",
         cardNsid: "card.exploration.frontier:pok/mirage",
         tokenNsid: "token.exploration:pok/mirage",
+        extraCardNsids: [
+            "card.planet:pok/mirage",
+            "card.legendary_planet:pok/mirage_flight_academy",
+        ],
     },
     {
         localeName: "token.attachment.nano_forge",

--- a/src/setup/setup-table-tokens.js
+++ b/src/setup/setup-table-tokens.js
@@ -1,3 +1,4 @@
+const locale = require("../lib/locale");
 const { AbstractSetup } = require("./abstract-setup");
 const { ObjectNamespace } = require("../lib/object-namespace");
 const { Spawn } = require("./spawn/spawn");
@@ -98,7 +99,9 @@ class SetupTableTokens extends AbstractSetup {
         );
         const rot = new Rotator(0, EXPLORATION_TOKENS.yaw, 0);
 
-        const bag = Spawn.spawn(EXPLORATION_TOKENS.bagNsid, pos, rot);
+        //const bag = Spawn.spawn(EXPLORATION_TOKENS.bagNsid, pos, rot);
+        const bag = Spawn.spawnGenericContainer(pos, rot);
+        bag.setName(locale("bag.exploration_tokens"));
         bag.clear(); // paranoia
         bag.setObjectType(ObjectType.Regular);
 

--- a/src/setup/setup-table-tokens.js
+++ b/src/setup/setup-table-tokens.js
@@ -139,8 +139,6 @@ class SetupTableTokens extends AbstractSetup {
             bag = Spawn.spawn(tokenData.bagNsid, pos, rot);
             bag.clear(); // paranoia
             bag.setObjectType(ObjectType.Regular);
-            bag.setScript("");
-            bag.setName("tokens");
 
             // Bag needs to have the correct type at create time.
             if (bag.getType() !== tokenData.bagType) {

--- a/src/setup/setup-table-tokens.js
+++ b/src/setup/setup-table-tokens.js
@@ -29,6 +29,14 @@ const GENERIC_TOKENS = [
         pos: { x: -10, y: -75, z: world.getTableHeight() + 5 },
         yaw: -90,
     },
+    {
+        tokenNsid: "token:base/custodians",
+        bagNsid: false,
+        bagType: false,
+        pos: { x: 0, y: -75, z: world.getTableHeight() + 5 },
+        yaw: 0,
+    },
+
     // scoreboard is in setup-table-mats
 ];
 

--- a/src/setup/spawn/template/nsid-token.json
+++ b/src/setup/spawn/template/nsid-token.json
@@ -82,5 +82,6 @@
     "token:base/speaker": "81F04C6F435D849CF50424B59E7E2F42",
     "token:base/tradegood_commodity_1": "2DB5DA894C75645C65F9CD86BFAEA211",
     "token:base/tradegood_commodity_3": "7E9C62F84C1DB934463888A52B748DF5",
-    "token:pok/frontier": "AB1E6E5C4A860EDEEC83FDA1991A1EC7"
+    "token:pok/frontier": "AB1E6E5C4A860EDEEC83FDA1991A1EC7",
+    "token:base/custodians": "09DF69524B6B7064D2CD6D8A0F7ADA59"
 }


### PR DESCRIPTION
- Show "take seat" when player leaves a seat.
- Do not show "diplomacy system" for Mecatol or zero-planet systems.
- Do not place Mallice if not using PoK.
- Exploring Mirage now draws cards.
- Custodians token.
- Do not move Strategy Cards during cleanup if already on the mat.
- Use a standard container for exploration tokens, visually different from graveyard/garbage boxes.