### PR TITLE
add right click option to purge items

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -55,7 +55,7 @@
 
     "ui.menu.place_agenda_top": "Place agenda top",
     "ui.menu.place_agenda_bottom": "Place agenda bottom",
-    
+
     "ui.menu.purge": "Purge",
 
     "ui.setup.title": "TWILIGHT IMPERIUM",

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,8 @@
     "ui.message.attach_token": "Attaching {attachmentName} to {planetName}",
     "ui.message.detach_token": "Detaching {attachmentName} from {planetName}",
 
+    "ui.message.purge": "Purging {objectName} card from the game.",
+
     "ui.message.stellar_converter": "Destroying {planetName} with Stellar Converter",
 
     "ui.message.player_rolling_for": "{playerName} rolling for {rollType}",
@@ -53,6 +55,8 @@
 
     "ui.menu.place_agenda_top": "Place agenda top",
     "ui.menu.place_agenda_bottom": "Place agenda bottom",
+    
+    "ui.menu.purge": "Purge",
 
     "ui.setup.title": "TWILIGHT IMPERIUM",
     "ui.setup.subtitle": "4th Edition",
@@ -450,6 +454,7 @@
     "bag.garbage": "Garbage",
     "bag.exploration_tokens": "Exploration Tokens",
     "bag.system_tiles": "System Tiles",
+    "bag.purge": "Purged Items",
 
     "token.dimensional_tear": "Dimensional Tear",
     "token.frontier": "Frontier",

--- a/src/global.js
+++ b/src/global.js
@@ -130,6 +130,7 @@ require("./global/patch-exclusive-bags");
 require("./global/r-swap-split-combine");
 require("./global/right-click/right-click-system");
 require("./global/right-click/right-click-agenda");
+require("./global/right-click/right-click-purge");
 require("./global/shuffle-decks-on-load");
 require("./global/strategy-card-functions");
 require("./global/trigger-on-system-activated");

--- a/src/global/right-click/right-click-agenda.js
+++ b/src/global/right-click/right-click-agenda.js
@@ -58,6 +58,21 @@ globalEvents.onObjectCreated.add((obj) => {
     }
 });
 
+// second to last card being drawn from a deck doesn't trigger onObjectCreated
+// for the last card in the deck
+for (const obj of world.getAllObjects()) {
+    if (obj instanceof Card && obj.getStackSize() > 1) {
+        obj.onRemoved.add((cardStack) => {
+            if (
+                cardStack.getStackSize() === 1 &&
+                ObjectNamespace.getNsid(cardStack).startsWith("card.agenda")
+            ) {
+                addRightClickOptions(obj);
+            }
+        });
+    }
+}
+
 // Script reload doesn't call onObjectCreated on existing objects, load manually.
 if (world.getExecutionReason() === "ScriptReload") {
     for (const obj of world.getAllObjects()) {

--- a/src/global/right-click/right-click-purge.js
+++ b/src/global/right-click/right-click-purge.js
@@ -1,0 +1,150 @@
+const assert = require("../../wrapper/assert-wrapper");
+const locale = require("../../lib/locale");
+const { ObjectNamespace } = require("../../lib/object-namespace");
+const { globalEvents, world, Card, Vector } = require("../../wrapper/api");
+const { Broadcast } = require("../../lib/broadcast");
+
+// create a container to hold the purged objects
+const PURGE_CONTAINER_TEMPLATE_ID = "A44BAA604E0ED034CD67FA9502214AA7";
+const PURGE_CONTAINER_POS = new Vector(-25, 113.3, 18);
+const PURGE_CONTAINER_NAME = "bag.purge";
+
+/**
+ * Creates a contianer to hold purged objects, if one doesn't already exist,
+ * otherwise returns the previous container.
+ *
+ * @returns { Container }
+ */
+function getPurgeContainer() {
+    for (const obj of world.getAllObjects()) {
+        if (obj.getName() === locale(PURGE_CONTAINER_NAME)) {
+            return obj;
+        }
+    }
+    const container = world.createObjectFromTemplate(
+        PURGE_CONTAINER_TEMPLATE_ID,
+        PURGE_CONTAINER_POS
+    );
+    container.setName(locale(PURGE_CONTAINER_NAME));
+    return container;
+}
+
+const PURGE_CONTAINER = getPurgeContainer();
+
+/**
+ * Moves card to the purged object container and broadcasts a message
+ * to report that the card was purged.
+ *
+ * @param {Card} card
+ */
+function purge(card) {
+    assert(card instanceof Card);
+    const objectName = ObjectNamespace.parseGeneric(card).name;
+    Broadcast.broadcastAll(
+        locale("ui.message.purge", { objectName: locale(objectName) })
+    );
+    PURGE_CONTAINER.addObjects([card], true);
+}
+
+/**
+ * Adds the right click option to purge a card.
+ *
+ * @param {Card} card
+ */
+function addRightClickOption(card) {
+    assert(card instanceof Card);
+    card.addCustomAction("*" + locale("ui.menu.purge"));
+    card.onCustomAction.add((card, _player, actionName) => {
+        if (actionName === "*" + locale("ui.menu.purge")) {
+            purge(card);
+        }
+    });
+}
+
+const PURGABLE_ATTACHMENTS = [
+    "research_facility",
+    "dmz",
+    "rich_world",
+    "paradise_world",
+    "tomb_of_emphidia",
+    "mining_world",
+    "lazax_survivors",
+    "dyson_sphere",
+];
+
+const PURGABLE_EXPLORES = [
+    "gamma",
+    "mirage",
+    "enigmatic_device",
+    "relic_fragment",
+];
+
+const PURGABLE_RELICS = [
+    "dominus_orb",
+    "maw_of_worlds",
+    "stellar_converter",
+    "the_codex",
+    "the_crown_of_emphidia",
+    "dynamis_core",
+    "nano_forge",
+];
+
+/**
+ * Returns true if the obj can be purged, returns false otherwise.
+ *
+ * @param {GameObject} obj
+ * @returns
+ */
+function canBePurged(obj) {
+    assert(obj instanceof GameObject);
+
+    if (!ObjectNamespace.isCard(obj)) {
+        return false;
+    }
+
+    const parsedCard = ObjectNamespace.parseCard(obj);
+    const deck = parsedCard.deck;
+    const name = parsedCard.name;
+
+    if (deck.startsWith("leader.hero")) {
+        return true;
+    }
+
+    if (deck.startsWith("exploration")) {
+        for (const explore of PURGABLE_EXPLORES) {
+            if (name.includes(explore)) {
+                return true;
+            }
+        }
+
+        // rules dont explicitly say to purge these, but the attachment scripts
+        // attach an icon to the planet card so theres no need to keep them around
+        for (const attachment of PURGABLE_ATTACHMENTS) {
+            if (name.includes(attachment)) {
+                return true;
+            }
+        }
+    }
+
+    if (deck.startsWith("relic")) {
+        for (const relic of PURGABLE_RELICS) {
+            if (name.includes(relic)) {
+                return true;
+            }
+        }
+    }
+}
+
+globalEvents.onObjectCreated.add((obj) => {
+    if (canBePurged(obj)) {
+        addRightClickOption(obj);
+    }
+});
+
+if (world.getExecutionReason() === "ScriptReload") {
+    for (const obj of world.getAllObjects()) {
+        if (canBePurged(obj)) {
+            addRightClickOption(obj);
+        }
+    }
+}

--- a/src/global/right-click/right-click-purge.js
+++ b/src/global/right-click/right-click-purge.js
@@ -141,6 +141,18 @@ globalEvents.onObjectCreated.add((obj) => {
     }
 });
 
+// second to last card being drawn from a deck doesn't trigger onObjectCreated
+// for the last card in the deck
+for (const obj of world.getAllObjects()) {
+    if (obj instanceof Card && obj.getStackSize() > 1) {
+        obj.onRemoved.add((cardStack) => {
+            if (cardStack.getStackSize() === 1 && canBePurged(cardStack)) {
+                addRightClickOption(obj);
+            }
+        });
+    }
+}
+
 if (world.getExecutionReason() === "ScriptReload") {
     for (const obj of world.getAllObjects()) {
         if (canBePurged(obj)) {


### PR DESCRIPTION
Decided to let players handle the muaat hero purging planet cards manually rather than add the right click option to all planet cards. Decided to let faction setup or the player handle purging the mahact alliance. Other than that I think I added the option to everything that needs it.

`onObjectCreated` only gets triggered for cards in a deck when they are drawn from the deck, but you can't draw the last card from the deck so it never triggers and the card doesn't get the option, reloading scripting will give it the option. The same thing is happening for the last agenda card. I'm not sure if this is on us or TTPG.