### PR TITLE
fix deal action card bug

### DIFF
--- a/src/lib/phase/end-of-round.js
+++ b/src/lib/phase/end-of-round.js
@@ -67,7 +67,8 @@ class DealActionCards {
             ])
         );
 
-        for (const playerSlot of FindTurnOrder.order()) {
+        for (const playerDesk of FindTurnOrder.order()) {
+            const playerSlot = playerDesk.playerSlot;
             const count =
                 DealActionCards.getNumberActionCardsToDeal(playerSlot);
             const message = locale("ui.message.deal_action_cards", {


### PR DESCRIPTION
FindTurnOrder.order was switched to returning player desks, grab slot from desk before determining how many action cards to deal