### PR TITLE
Rearrange Unit Upgrades on Technology Strat Popup

### DIFF
--- a/src/lib/technology/technology.data.js
+++ b/src/lib/technology/technology.data.js
@@ -216,6 +216,7 @@ module.exports = [
             Green: 2,
         },
         abbrev: "Infantry II",
+		unitPosition: 10,
     },
     {
         localeName: "unit.destroyer_2",
@@ -225,6 +226,7 @@ module.exports = [
             Red: 2,
         },
         abbrev: "Destroyer II",
+		unitPosition: 5,
     },
     {
         localeName: "unit.carrier_2",
@@ -234,6 +236,7 @@ module.exports = [
             Blue: 2,
         },
         abbrev: "Carrier II",
+		unitPosition: 8,
     },
     {
         localeName: "unit.space_dock_2",
@@ -243,6 +246,7 @@ module.exports = [
             Yellow: 2,
         },
         abbrev: "Space Dock II",
+		unitPosition: 11,
     },
     {
         localeName: "unit.fighter_2",
@@ -253,6 +257,7 @@ module.exports = [
             Green: 1,
         },
         abbrev: "Fighter II",
+		unitPosition: 9,
     },
     {
         localeName: "unit.pds_2",
@@ -263,6 +268,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "PDS II",
+		unitPosition: 6,
     },
     {
         localeName: "unit.cruiser_2",
@@ -274,6 +280,7 @@ module.exports = [
             Green: 1,
         },
         abbrev: "Cruiser II",
+		unitPosition: 1,
     },
     {
         localeName: "unit.dreadnought_2",
@@ -284,6 +291,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "Dread II",
+		unitPosition: 4,
     },
     {
         localeName: "unit.war_sun",
@@ -294,6 +302,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "War Sun",
+		unitPosition: 0,
     },
 
     {
@@ -305,6 +314,7 @@ module.exports = [
         },
         abbrev: "Letani II",
         faction: "arborec",
+		unitPosition: 10,
     },
     {
         localeName: "technology.name.bioplasmosis",
@@ -355,6 +365,7 @@ module.exports = [
         },
         abbrev: " FF II",
         faction: "saar",
+		unitPosition: 11,
     },
     {
         localeName: "unit.war_sun.prototype_war_sun_2",
@@ -366,6 +377,7 @@ module.exports = [
         },
         abbrev: " PWS II",
         faction: "muaat",
+		unitPosition: 0,
     },
     {
         localeName: "technology.name.magmus_reactor",
@@ -406,6 +418,7 @@ module.exports = [
         },
         abbrev: "Spec Ops II",
         faction: "sol",
+		unitPosition: 10,
     },
     {
         localeName: "unit.carrier.advanced_carrier_2",
@@ -416,6 +429,7 @@ module.exports = [
         },
         abbrev: "Adv Carrier II",
         faction: "sol",
+		unitPosition: 8,
     },
     {
         localeName: "technology.name.wormhole_generator",
@@ -447,6 +461,7 @@ module.exports = [
         },
         abbrev: "SuperDread II",
         faction: "l1z1x",
+		unitPosition: 4,
     },
     {
         localeName: "technology.name.inheritance_systems",
@@ -489,6 +504,7 @@ module.exports = [
         },
         abbrev: " HCF II",
         faction: "naalu",
+		unitPosition: 9,
     },
     {
         localeName: "technology.name.neuroglaive",
@@ -526,6 +542,7 @@ module.exports = [
         },
         abbrev: "Exotrireme II",
         faction: "norr",
+		unitPosition: 4,
     },
     {
         localeName: "technology.name.valkyrie_particle_weave",
@@ -661,6 +678,7 @@ module.exports = [
         abbrev: "Memoria II",
         faction: "nomad",
         source: "PoK",
+		unitPosition: -4,
     },
     {
         localeName: "technology.name.vortex",
@@ -684,6 +702,7 @@ module.exports = [
         abbrev: "Dim Tear II",
         faction: "vuilraith",
         source: "PoK",
+		unitPosition: 11,
     },
     {
         localeName: "technology.name.aerie_hololattice",
@@ -706,6 +725,7 @@ module.exports = [
         abbrev: "String Wing II",
         faction: "argent",
         source: "PoK",
+		unitPosition: 5,
     },
     {
         localeName: "unit.cruiser.saturn_engine_2",
@@ -719,6 +739,7 @@ module.exports = [
         abbrev: "Sat Eng II",
         faction: "ul",
         source: "PoK",
+		unitPosition: 1,
     },
     {
         localeName: "unit.pds.hel_titan_2",
@@ -731,6 +752,7 @@ module.exports = [
         abbrev: "Hel-Titan II",
         faction: "ul",
         source: "PoK",
+		unitPosition: 6,
     },
     {
         localeName: "technology.name.aetherstream",
@@ -766,6 +788,7 @@ module.exports = [
         abbrev: "Crimson Legin II",
         faction: "mahact",
         source: "PoK",
+		unitPosition: 10,
     },
     {
         localeName: "technology.name.genetic_recombination",
@@ -809,6 +832,7 @@ module.exports = [
         },
         abbrev: "Scenario Destroyer",
         source: "Codex 1",
+		unitPosition: 5,
     },
     {
         localeName: "technology.name.exception_no_id",

--- a/src/lib/technology/technology.data.js
+++ b/src/lib/technology/technology.data.js
@@ -216,7 +216,7 @@ module.exports = [
             Green: 2,
         },
         abbrev: "Infantry II",
-		unitPosition: 10,
+        unitPosition: 10,
     },
     {
         localeName: "unit.destroyer_2",
@@ -226,7 +226,7 @@ module.exports = [
             Red: 2,
         },
         abbrev: "Destroyer II",
-		unitPosition: 5,
+        unitPosition: 5,
     },
     {
         localeName: "unit.carrier_2",
@@ -236,7 +236,7 @@ module.exports = [
             Blue: 2,
         },
         abbrev: "Carrier II",
-		unitPosition: 8,
+        unitPosition: 8,
     },
     {
         localeName: "unit.space_dock_2",
@@ -246,7 +246,7 @@ module.exports = [
             Yellow: 2,
         },
         abbrev: "Space Dock II",
-		unitPosition: 11,
+        unitPosition: 11,
     },
     {
         localeName: "unit.fighter_2",
@@ -257,7 +257,7 @@ module.exports = [
             Green: 1,
         },
         abbrev: "Fighter II",
-		unitPosition: 9,
+        unitPosition: 9,
     },
     {
         localeName: "unit.pds_2",
@@ -268,7 +268,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "PDS II",
-		unitPosition: 6,
+        unitPosition: 6,
     },
     {
         localeName: "unit.cruiser_2",
@@ -280,7 +280,7 @@ module.exports = [
             Green: 1,
         },
         abbrev: "Cruiser II",
-		unitPosition: 1,
+        unitPosition: 1,
     },
     {
         localeName: "unit.dreadnought_2",
@@ -291,7 +291,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "Dread II",
-		unitPosition: 4,
+        unitPosition: 4,
     },
     {
         localeName: "unit.war_sun",
@@ -302,7 +302,7 @@ module.exports = [
             Yellow: 1,
         },
         abbrev: "War Sun",
-		unitPosition: 0,
+        unitPosition: 0,
     },
 
     {
@@ -314,7 +314,7 @@ module.exports = [
         },
         abbrev: "Letani II",
         faction: "arborec",
-		unitPosition: 10,
+        unitPosition: 10,
     },
     {
         localeName: "technology.name.bioplasmosis",
@@ -365,7 +365,7 @@ module.exports = [
         },
         abbrev: " FF II",
         faction: "saar",
-		unitPosition: 11,
+        unitPosition: 11,
     },
     {
         localeName: "unit.war_sun.prototype_war_sun_2",
@@ -377,7 +377,7 @@ module.exports = [
         },
         abbrev: " PWS II",
         faction: "muaat",
-		unitPosition: 0,
+        unitPosition: 0,
     },
     {
         localeName: "technology.name.magmus_reactor",
@@ -418,7 +418,7 @@ module.exports = [
         },
         abbrev: "Spec Ops II",
         faction: "sol",
-		unitPosition: 10,
+        unitPosition: 10,
     },
     {
         localeName: "unit.carrier.advanced_carrier_2",
@@ -429,7 +429,7 @@ module.exports = [
         },
         abbrev: "Adv Carrier II",
         faction: "sol",
-		unitPosition: 8,
+        unitPosition: 8,
     },
     {
         localeName: "technology.name.wormhole_generator",
@@ -461,7 +461,7 @@ module.exports = [
         },
         abbrev: "SuperDread II",
         faction: "l1z1x",
-		unitPosition: 4,
+        unitPosition: 4,
     },
     {
         localeName: "technology.name.inheritance_systems",
@@ -504,7 +504,7 @@ module.exports = [
         },
         abbrev: " HCF II",
         faction: "naalu",
-		unitPosition: 9,
+        unitPosition: 9,
     },
     {
         localeName: "technology.name.neuroglaive",
@@ -542,7 +542,7 @@ module.exports = [
         },
         abbrev: "Exotrireme II",
         faction: "norr",
-		unitPosition: 4,
+        unitPosition: 4,
     },
     {
         localeName: "technology.name.valkyrie_particle_weave",
@@ -678,7 +678,7 @@ module.exports = [
         abbrev: "Memoria II",
         faction: "nomad",
         source: "PoK",
-		unitPosition: -4,
+        unitPosition: -4,
     },
     {
         localeName: "technology.name.vortex",
@@ -702,7 +702,7 @@ module.exports = [
         abbrev: "Dim Tear II",
         faction: "vuilraith",
         source: "PoK",
-		unitPosition: 11,
+        unitPosition: 11,
     },
     {
         localeName: "technology.name.aerie_hololattice",
@@ -725,7 +725,7 @@ module.exports = [
         abbrev: "String Wing II",
         faction: "argent",
         source: "PoK",
-		unitPosition: 5,
+        unitPosition: 5,
     },
     {
         localeName: "unit.cruiser.saturn_engine_2",
@@ -739,7 +739,7 @@ module.exports = [
         abbrev: "Sat Eng II",
         faction: "ul",
         source: "PoK",
-		unitPosition: 1,
+        unitPosition: 1,
     },
     {
         localeName: "unit.pds.hel_titan_2",
@@ -752,7 +752,7 @@ module.exports = [
         abbrev: "Hel-Titan II",
         faction: "ul",
         source: "PoK",
-		unitPosition: 6,
+        unitPosition: 6,
     },
     {
         localeName: "technology.name.aetherstream",
@@ -788,7 +788,7 @@ module.exports = [
         abbrev: "Crimson Legin II",
         faction: "mahact",
         source: "PoK",
-		unitPosition: 10,
+        unitPosition: 10,
     },
     {
         localeName: "technology.name.genetic_recombination",
@@ -832,7 +832,7 @@ module.exports = [
         },
         abbrev: "Scenario Destroyer",
         source: "Codex 1",
-		unitPosition: 5,
+        unitPosition: 5,
     },
     {
         localeName: "technology.name.exception_no_id",

--- a/src/objects/strategy-cards/technology.js
+++ b/src/objects/strategy-cards/technology.js
@@ -12,7 +12,6 @@ const {
     world,
 } = require("../../wrapper/api");
 const { Broadcast } = require("../../lib/broadcast");
-const { ColorUtil } = require("../../lib/color/color-util");
 const { Technology } = require("../../lib/technology/technology");
 const locale = require("../../lib/locale");
 const assert = require("../../wrapper/assert-wrapper");
@@ -48,25 +47,25 @@ const factionIcons = {
 
 const techIcons = {
     unitUpgrade: {
-        color: ColorUtil.colorFromHex("#ffffff"),
+        color: new Color(1, 1, 1),
     },
     Red: {
-        color: ColorUtil.colorFromHex("#cc0000"),
+        color: new Color(1, 0, 0),
         activeIcon: "global/technology/warfare_tech_icon.png",
         disabledIcon: "global/technology/warfare_tech_disabled_icon.png",
     },
     Yellow: {
-        color: ColorUtil.colorFromHex("#e5e500"),
+        color: new Color(1, 1, 0),
         activeIcon: "global/technology/cybernetic_tech_icon.png",
         disabledIcon: "global/technology/cybernetic_tech_disabled_icon.png",
     },
     Green: {
-        color: ColorUtil.colorFromHex("#008000"),
+        color: new Color(0, 1, 0),
         activeIcon: "global/technology/biotic_tech_icon.png",
         disabledIcon: "global/technology/biotic_tech_disabled_icon.png",
     },
     Blue: {
-        color: ColorUtil.colorFromHex("#3232ff"),
+        color: new Color(0, 0, 1),
         activeIcon: "global/technology/propulsion_tech_icon.png",
         disabledIcon: "global/technology/propulsion_tech_disabled_icon.png",
     },
@@ -231,11 +230,9 @@ function widgetFactory(playerDesk, packageId) {
                 packageId
             );
 
-            // Always add offset for consistent layout
-            //if (Object.keys(tech.requirements).length > 0) {
-            //   yOffset += 15;
-            //}
-            yOffset += 15;
+            if (Object.keys(tech.requirements).length > 0) {
+                yOffset += 15;
+            }
 
             yOffset += 40;
         });
@@ -245,8 +242,8 @@ function widgetFactory(playerDesk, packageId) {
 
     technologies.unitUpgrade.forEach((tech, index) => {
         let techButton = new Button().setText(tech.name);
-        const xOffset = (index % 4) * 210;
-        const yOffset = yOffsetMax + 20 + Math.floor(index / 4) * 60;
+        const xOffset = (tech.unitPosition % 4) * 210;
+        const yOffset = yOffsetMax + 20 + Math.floor(tech.unitPosition / 4) * 60;
         canvas.addChild(techButton, xOffset, yOffset, 200, 35);
 
         drawTechButton(
@@ -282,7 +279,7 @@ const calculateHeight = (playerSlot) => {
         .map((type) => technologies[type].length)
         .reduce((a, b) => Math.max(a, b));
     const unitUpgradeRows = Math.ceil(technologies.unitUpgrade.length / 4);
-    return (techRows + unitUpgradeRows) * 55 + 130;
+    return (techRows + unitUpgradeRows) * 55 + 100;
 };
 
 new RegisterStrategyCardUI()

--- a/src/objects/strategy-cards/technology.js
+++ b/src/objects/strategy-cards/technology.js
@@ -243,7 +243,8 @@ function widgetFactory(playerDesk, packageId) {
     technologies.unitUpgrade.forEach((tech, index) => {
         let techButton = new Button().setText(tech.name);
         const xOffset = (tech.unitPosition % 4) * 210;
-        const yOffset = yOffsetMax + 20 + Math.floor(tech.unitPosition / 4) * 60;
+        const yOffset = yOffsetMax + 20 + 
+          Math.floor(tech.unitPosition / 4) * 60;
         canvas.addChild(techButton, xOffset, yOffset, 200, 35);
 
         drawTechButton(

--- a/src/objects/strategy-cards/technology.js
+++ b/src/objects/strategy-cards/technology.js
@@ -243,8 +243,8 @@ function widgetFactory(playerDesk, packageId) {
     technologies.unitUpgrade.forEach((tech, index) => {
         let techButton = new Button().setText(tech.name);
         const xOffset = (tech.unitPosition % 4) * 210;
-        const yOffset = yOffsetMax + 20 + 
-            Math.floor(tech.unitPosition / 4) * 60;
+        const yOffset =
+            yOffsetMax + 20 + Math.floor(tech.unitPosition / 4) * 60;
         canvas.addChild(techButton, xOffset, yOffset, 200, 35);
 
         drawTechButton(

--- a/src/objects/strategy-cards/technology.js
+++ b/src/objects/strategy-cards/technology.js
@@ -244,7 +244,7 @@ function widgetFactory(playerDesk, packageId) {
         let techButton = new Button().setText(tech.name);
         const xOffset = (tech.unitPosition % 4) * 210;
         const yOffset = yOffsetMax + 20 + 
-          Math.floor(tech.unitPosition / 4) * 60;
+            Math.floor(tech.unitPosition / 4) * 60;
         canvas.addChild(techButton, xOffset, yOffset, 200, 35);
 
         drawTechButton(


### PR DESCRIPTION
This will rearrange the positions of unit upgrades on the technology popup to match the locations of the units on faction sheets.

![20220309095808_1](https://user-images.githubusercontent.com/42644678/157346638-a576e5e9-f270-4b68-b561-848f2e647cbc.jpg)

![20220309095819_1](https://user-images.githubusercontent.com/42644678/157346649-bb5c9613-6c64-4764-b007-75d28c680c57.jpg)

![20220309095843_1](https://user-images.githubusercontent.com/42644678/157346657-728d68eb-d1ef-47fe-b5c8-b085b6c34a7d.jpg)