### PR TITLE
Rift roller

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -63,6 +63,11 @@
     "ui.message.player_landed_hits": "{playerName} landed {hits} {#hits|hit|hits}",
     "ui.message.roll.hit": "HIT",
     "ui.message.roll.crit": "CRIT",
+    "ui.message.roll.gravRift": "{playerName} rolling for gravity rift: ",
+    "ui.message.roll.gravRiftSuccess": "{value}: Ship survives!",
+    "ui.message.roll.gravRiftFailure": "{value}: Ship is removed!",
+    "ui.message.roll.autoGravRiftSuccess": "{value}: {unit} survives!",
+    "ui.message.roll.autoGravRiftFailure": "{value}: {unit} is removed!",
 
     "ui.message.command_tokens_removed": "{factionName} withdrew {count} command {#count|token|tokens}",
     "ui.message.command_tokens_inserted": "{factionName} deposited {count} command {#count|token|tokens}",
@@ -105,6 +110,8 @@
     "ui.action.system.control": "Control Token",
     "ui.action.system.explore": "Explore {planetName}",
     "ui.action.system.distant_suns_explore": "Explore {planetName} with Distant Suns",
+    "ui.action.system.rift_roll": "Roll for Gravity Rift",
+    "ui.action.system.auto_rift_roll": "Grav Rift all ships in system",
     "ui.button.end_turn": "END TURN",
 
     "ui.label.speaker": "Speaker",

--- a/src/global/right-click/grav-rift-roller.js
+++ b/src/global/right-click/grav-rift-roller.js
@@ -126,15 +126,17 @@ class AutoGravRiftRoller {
 
         const diceObjects = [];
         plasticWithMovement.forEach((unit) => {
-            const yaw = Math.random() * 360;
-            const d = new Vector(5, 0, 10).rotateAngleAxis(yaw, [0, 0, 1]);
-            const pos = systemTileObj.getPosition().add(d);
-            const die = new SimpleDieBuilder()
-                .setDeleteAfterSeconds(DELETE_DIE_AFTER_N_SECONDS)
-                .setHitValue(GRAV_RIFT_SUCCCESS)
-                .setSpawnPosition(pos)
-                .build(player);
-            diceObjects.push([die, unit]);
+            for (var i = 0; i < unit._count; i++) {
+                const yaw = Math.random() * 360;
+                const d = new Vector(5, 0, 10).rotateAngleAxis(yaw, [0, 0, 1]);
+                const pos = systemTileObj.getPosition().add(d);
+                const die = new SimpleDieBuilder()
+                    .setDeleteAfterSeconds(DELETE_DIE_AFTER_N_SECONDS)
+                    .setHitValue(GRAV_RIFT_SUCCCESS)
+                    .setSpawnPosition(pos)
+                    .build(player);
+                diceObjects.push([die, unit, i]);
+            }
         });
         FancyRollGroup.roll(diceObjects, (diceObjects) => {
             AutoGravRiftRoller.onRollFinished(diceObjects, player);
@@ -150,8 +152,8 @@ class AutoGravRiftRoller {
         const color = playerDesk ? playerDesk.color : player.getPlayerColor();
 
         const parts = [];
-        for (const [die, unit] of diceObjects) {
-            AutoGravRiftRoller.addLabel(die, unit, player);
+        for (const [die, unit, index] of diceObjects) {
+            AutoGravRiftRoller.addLabel(die, unit, index, player);
             if (die.isHit()) {
                 parts.push(
                     locale("ui.message.roll.autoGravRiftSuccess", {
@@ -173,11 +175,11 @@ class AutoGravRiftRoller {
         Broadcast.broadcastAll(msg, color);
     }
 
-    static addLabel(die, unit, player) {
+    static addLabel(die, unit, index, player) {
         const gameObject = unit.gameObject;
         const label = new UIElement();
         label.widget = new Border();
-        label.position = new Vector(0, 0, 1.5);
+        label.position = new Vector(index * 2.5, 0, 1.5);
         if (die.isHit()) {
             const msg = locale("ui.message.roll.autoGravRiftSuccess", {
                 value: die.getValue(),

--- a/src/global/right-click/grav-rift-roller.js
+++ b/src/global/right-click/grav-rift-roller.js
@@ -1,0 +1,210 @@
+const { Vector, UIElement, Text, Color, Border } = require("../../wrapper/api");
+const { SimpleDieBuilder } = require("../../lib/dice/simple-die");
+const { RollGroup, FancyRollGroup } = require("../../lib/dice/roll-group");
+const locale = require("../../lib/locale");
+const { Broadcast } = require("../../lib/broadcast");
+const { AuxDataBuilder } = require("../../lib/unit/auxdata");
+const { Hex } = require("../../lib/hex");
+const { AuxDataPair } = require("../../lib/unit/auxdata-pair");
+const { UnitPlastic } = require("../../lib/unit/unit-plastic");
+
+const DELETE_DIE_AFTER_N_SECONDS = 10;
+const DELETE_LABEL_AFTER_N_MSECS = 15000;
+const WAIT_MSECS_BEFORE_ROLL = 2500;
+const GRAV_RIFT_SUCCCESS = 4;
+const LABEL_FONT_SIZE = 8;
+
+class SimpleGravRiftRoller {
+    static {
+        this._pendingDice = [];
+        this._pendingRollHandle = undefined;
+    }
+
+    /**
+     * Rolls a D10 and reports gravity rift result.
+     *
+     * 1-3 = failure, 4-10 = success.
+     *
+     * @param {GameObject} systemTileObj
+     * @param {Player} player
+     * @returns
+     */
+    static roll(systemTileObj, player) {
+        const yaw = Math.random() * 360;
+        const d = new Vector(5, 0, 10).rotateAngleAxis(yaw, [0, 0, 1]);
+        const pos = systemTileObj.getPosition().add(d);
+        const simpleDie = new SimpleDieBuilder()
+            .setDeleteAfterSeconds(DELETE_DIE_AFTER_N_SECONDS)
+            .setHitValue(GRAV_RIFT_SUCCCESS)
+            .setSpawnPosition(pos)
+            .build(player);
+        this._pendingDice.push(simpleDie);
+
+        if (!this._pendingRollHandle) {
+            clearTimeout(this._pendingRollHandle);
+        }
+        this._pendingRollHandle = setTimeout(() => {
+            SimpleGravRiftRoller.doRoll(player);
+        }, WAIT_MSECS_BEFORE_ROLL);
+    }
+
+    static doRoll(player) {
+        const dice = this._pendingDice;
+        this._pendingDice = [];
+        this._pendingRollHandle = undefined;
+        RollGroup.roll(dice, (dice) => {
+            SimpleGravRiftRoller.onRollFinished(dice, player);
+        });
+    }
+
+    static onRollFinished(dice, player) {
+        const playerSlot = player.getSlot();
+        const playerDesk = world.TI4.getPlayerDeskByPlayerSlot(playerSlot);
+        const deskName = playerDesk ? playerDesk.colorName : player.getName();
+        const faction = world.TI4.getFactionByPlayerSlot(playerSlot);
+        const playerName = faction ? faction.nameFull : deskName;
+        const color = playerDesk ? playerDesk.color : player.getPlayerColor();
+
+        const parts = [];
+        for (const die of dice) {
+            if (die.isHit()) {
+                parts.push(
+                    locale("ui.message.roll.gravRiftSuccess", {
+                        value: die.getValue(),
+                    })
+                );
+            } else {
+                parts.push(
+                    locale("ui.message.roll.gravRiftFailure", {
+                        value: die.getValue(),
+                    })
+                );
+            }
+        }
+        const prefix = locale("ui.message.roll.gravRift", { playerName });
+        const msg = prefix + parts.join(" ");
+        Broadcast.broadcastAll(msg, color);
+    }
+}
+
+class AutoGravRiftRoller {
+    /**
+     * Rolls a D10 for each ship with movement in the system.
+     *
+     * 1-3 = failure, 4-10 = success.
+     *
+     * Reports result per ship by adding temporary label to ship.
+     *
+     * @param {GameObject} systemTileObj
+     * @param {Player} player
+     * @returns
+     */
+    static roll(systemTileObj, player) {
+        const system = world.TI4.getSystemBySystemTileObject(systemTileObj);
+        const playerSlot = player.getSlot();
+        const faction = world.TI4.getFactionByPlayerSlot(playerSlot);
+        const hex = Hex.fromPosition(systemTileObj.getPosition());
+
+        // get per-unit data.
+        const auxData = new AuxDataBuilder()
+            .setPlayerSlot(playerSlot)
+            .setFaction(faction)
+            .build();
+
+        // Apply unit upgrades.
+        new AuxDataPair(auxData, new AuxDataBuilder().build()).fillPairSync();
+
+        const hexPlastic = UnitPlastic.getAll().filter(
+            (plastic) => plastic.hex === hex
+        );
+
+        const plasticWithMovement = hexPlastic.filter((plastic) => {
+            const unit = plastic.unit;
+            const attrs = auxData.unitAttrsSet.get(unit);
+            return attrs.raw.move > 0;
+        });
+
+        const diceObjects = [];
+        plasticWithMovement.forEach((unit) => {
+            const yaw = Math.random() * 360;
+            const d = new Vector(5, 0, 10).rotateAngleAxis(yaw, [0, 0, 1]);
+            const pos = systemTileObj.getPosition().add(d);
+            const die = new SimpleDieBuilder()
+                .setDeleteAfterSeconds(DELETE_DIE_AFTER_N_SECONDS)
+                .setHitValue(GRAV_RIFT_SUCCCESS)
+                .setSpawnPosition(pos)
+                .build(player);
+            diceObjects.push([die, unit]);
+        });
+        FancyRollGroup.roll(diceObjects, (diceObjects) => {
+            AutoGravRiftRoller.onRollFinished(diceObjects, player);
+        });
+    }
+
+    static onRollFinished(diceObjects, player) {
+        const playerSlot = player.getSlot();
+        const playerDesk = world.TI4.getPlayerDeskByPlayerSlot(playerSlot);
+        const deskName = playerDesk ? playerDesk.colorName : player.getName();
+        const faction = world.TI4.getFactionByPlayerSlot(playerSlot);
+        const playerName = faction ? faction.nameFull : deskName;
+        const color = playerDesk ? playerDesk.color : player.getPlayerColor();
+
+        const parts = [];
+        for (const [die, unit] of diceObjects) {
+            AutoGravRiftRoller.addLabel(die, unit, player);
+            if (die.isHit()) {
+                parts.push(
+                    locale("ui.message.roll.autoGravRiftSuccess", {
+                        value: die.getValue(),
+                        unit: unit.unit,
+                    })
+                );
+            } else {
+                parts.push(
+                    locale("ui.message.roll.autoGravRiftFailure", {
+                        value: die.getValue(),
+                        unit: unit.unit,
+                    })
+                );
+            }
+        }
+        const prefix = locale("ui.message.roll.gravRift", { playerName });
+        const msg = prefix + parts.join(" ");
+        Broadcast.broadcastAll(msg, color);
+    }
+
+    static addLabel(die, unit, player) {
+        const gameObject = unit.gameObject;
+        const label = new UIElement();
+        label.widget = new Border();
+        label.position = new Vector(0, 0, 1.5);
+        if (die.isHit()) {
+            const msg = locale("ui.message.roll.autoGravRiftSuccess", {
+                value: die.getValue(),
+                unit: unit.unit,
+            });
+            label.widget.setChild(
+                new Text().setText(msg).setFontSize(LABEL_FONT_SIZE)
+            );
+        } else {
+            const msg = locale("ui.message.roll.autoGravRiftFailure", {
+                value: die.getValue(),
+                unit: unit.unit,
+            });
+            label.widget.setChild(
+                new Text()
+                    .setText(msg)
+                    .setFontSize(LABEL_FONT_SIZE)
+                    .setTextColor(new Color(255, 0, 0))
+            );
+        }
+        const localRot = gameObject.worldRotationToLocal(player.getRotation());
+        label.rotation.yaw = localRot.yaw;
+        gameObject.addUI(label);
+        setTimeout(() => {
+            gameObject.removeUI(0);
+        }, DELETE_LABEL_AFTER_N_MSECS);
+    }
+}
+
+module.exports = { SimpleGravRiftRoller, AutoGravRiftRoller };

--- a/src/global/right-click/right-click-system.js
+++ b/src/global/right-click/right-click-system.js
@@ -6,6 +6,10 @@ const { Explore } = require("../../lib/explore/explore");
 const { ObjectNamespace } = require("../../lib/object-namespace");
 const { PopupPanel } = require("../../lib/ui/popup-panel");
 const {
+    SimpleGravRiftRoller,
+    AutoGravRiftRoller,
+} = require("./grav-rift-roller");
+const {
     GameObject,
     Player,
     Vector,
@@ -38,6 +42,23 @@ function getNamesAndActions(player, systemTileObj) {
             },
         },
     ];
+
+    const system = world.TI4.getSystemBySystemTileObject(systemTileObj);
+    if (system && system.anomalies.includes("gravity rift")) {
+        namesAndActions.push({
+            name: locale("ui.action.system.rift_roll"),
+            action: (player) => {
+                SimpleGravRiftRoller.roll(systemTileObj, player);
+            },
+            delayedHide: true,
+        });
+        namesAndActions.push({
+            name: locale("ui.action.system.auto_rift_roll"),
+            action: (player) => {
+                AutoGravRiftRoller.roll(systemTileObj, player);
+            },
+        });
+    }
 
     const exploreNamesAndActions = Explore.getExploreActionNamesAndActions(
         systemTileObj,
@@ -89,11 +110,15 @@ function addRightClickOptions(systemTileObj) {
     popupPanel.onShow.add((obj, player, popupPanel) => {
         popupPanel.reset();
         const namesAndActions = getNamesAndActions(player, systemTileObj);
-        for (const { name, action } of namesAndActions) {
-            popupPanel.addAction(name, (obj, player, actionName) => {
-                assert(player instanceof Player);
-                action(player);
-            });
+        for (const nameAndAction of namesAndActions) {
+            popupPanel.addAction(
+                nameAndAction.name,
+                (obj, player, actionName) => {
+                    assert(player instanceof Player);
+                    nameAndAction.action(player);
+                },
+                nameAndAction.delayedHide
+            );
         }
     });
 }

--- a/src/lib/dice/roll-group.js
+++ b/src/lib/dice/roll-group.js
@@ -26,4 +26,36 @@ class RollGroup {
     }
 }
 
-module.exports = { RollGroup };
+/**
+ * Does everything that RollGroup does, but allows each die to be associated
+ * with an object. Used by AutoGravRiftRoller.
+ *
+ * Dice should now be an Array<Array> where each element of dice is
+ * [SimpleDie, <thing to attach the roll result to>].
+ */
+class FancyRollGroup {
+    static roll(dice, callback) {
+        assert(Array.isArray(dice));
+        for (const [die, obj] of dice) {
+            assert(die instanceof SimpleDie);
+        }
+        assert(typeof callback === "function");
+
+        const perDieCallback = (simpleDie) => {
+            assert(simpleDie instanceof SimpleDie);
+            for (const [die, _obj] of dice) {
+                if (die.isRolling()) {
+                    return;
+                }
+            }
+            // All dice finished rolling!
+            callback(dice);
+        };
+
+        for (const [die, _obj] of dice) {
+            die.roll(perDieCallback);
+        }
+    }
+}
+
+module.exports = { RollGroup, FancyRollGroup };

--- a/src/lib/ui/popup-panel.js
+++ b/src/lib/ui/popup-panel.js
@@ -15,6 +15,7 @@ const {
 
 const POPUP_HEIGHT = 3;
 const POPUP_CHILD_DISTANCE = 5; // consistent look
+const DELAYED_HIDE_MSECS = 2500;
 
 /**
  * Popup "panel" (Border) with custom actions.
@@ -104,10 +105,11 @@ class PopupPanel extends Border {
      * @param {function} onActionCallback - f(gameObject, player, actionName)
      * @returns {PopupPanel} self, for chaining
      */
-    addAction(actionName, onActionCallback) {
+    addAction(actionName, onActionCallback, delayedHide) {
         this._namesAndActions.push({
             name: actionName,
             action: onActionCallback,
+            delayedHide: delayedHide,
         });
         return this;
     }
@@ -124,10 +126,16 @@ class PopupPanel extends Border {
 
         // Add owner-specified actions, followed by cancel.
         const panel = new VerticalBox().setChildDistance(POPUP_CHILD_DISTANCE);
-        for (const { name, action } of this._namesAndActions) {
+        for (const { name, action, delayedHide } of this._namesAndActions) {
             const button = new Button().setText(name);
             button.onClicked.add((button, player) => {
-                this._hide();
+                if (delayedHide) {
+                    setTimeout(() => {
+                        this._hide();
+                    }, DELAYED_HIDE_MSECS);
+                } else {
+                    this._hide();
+                }
                 action(this._obj, player, name);
             });
             panel.addChild(button);

--- a/src/objects/tokens/dimensional-tear.js
+++ b/src/objects/tokens/dimensional-tear.js
@@ -14,11 +14,11 @@ class DimensionalTear extends AbstractSystemAttachment {
     }
 
     place(system, planet, systemTileObj) {
-        system.anomalies.push("gravity_rift");
+        system.anomalies.push("gravity rift");
     }
 
     remove(system, planet, systemTileObj) {
-        const index = system.anomalies.indexOf("gravity_rift");
+        const index = system.anomalies.indexOf("gravity rift");
         system.anomalies.splice(index, 1);
     }
 }


### PR DESCRIPTION
Adds 2 gravity rift roll options:
A basic one that rolls a die and reports success if greater than 3.
An auto one that rolls a die for every ship with movement in the system and reports success if greater than 3 for each one by logging it in the console with the unit type and by adding a temporary label to the unit's game object.

I'm not sure the auto roll is an improvement. I added a label to each game object to indicate success/failure in case there are two of the same unit carrying different things and one succeeds and the other doesn't. I also decided to always roll for all fighter 2s since that was simpler than determining which were being carried. This means that if there is a lot of ships (or a reasonable number of fighter 2s) in the system it creates a pretty big mess that the player has to deal with before the labels dissapear (12 seconds right now). Leaving it here so others can see if they like it.