### PR TITLE
[milty] replace adj anomaly swapping with unbiased implementation

### DIFF
--- a/src/lib/draft/milty/milty-slice-generator.test.js
+++ b/src/lib/draft/milty/milty-slice-generator.test.js
@@ -13,8 +13,6 @@ const { MiltySliceGenerator } = require("./milty-slice-generator");
 // });
 
 it("fix adj anomalies", () => {
-    const sliceGenerator = new MiltySliceGenerator();
-
     // 0 anomalies
     let generatedSlice = [19, 20, 21, 22, 23];
     let actual = MiltySliceGenerator.fixAdjAnomalies(generatedSlice);
@@ -27,19 +25,36 @@ it("fix adj anomalies", () => {
     expected = generatedSlice;
     assert.deepEqual(actual, expected);
 
-    // 2 anomalies, deterministic swap
-    generatedSlice = [19, 41, 21, 42, 23];
+    // 2 anomalies in 0,2 positions (valid)
+    generatedSlice = [41, 20, 42, 22, 23];
     actual = MiltySliceGenerator.fixAdjAnomalies(generatedSlice);
-    expected = [19, 21, 41, 42, 23];
+    expected = generatedSlice;
     assert.deepEqual(actual, expected);
 
-    // 2 anomalies, non-deterministic swap
+    // 2 anomalies in 1,3 positions
+    generatedSlice = [19, 41, 21, 42, 23];
+    actual = MiltySliceGenerator.fixAdjAnomalies(generatedSlice);
+    let validResults = [
+        [41, 19, 42, 21, 23],
+        [41, 19, 21, 23, 42],
+        [19, 21, 41, 42, 23],
+        [19, 21, 41, 23, 42],
+    ];
+    assert.ok(validResults.some((result) => lodash.isEqual(result, actual)));
+
+    // 2 anomalies in 3,4 positions
     generatedSlice = [19, 20, 21, 41, 42];
     actual = MiltySliceGenerator.fixAdjAnomalies(generatedSlice);
-    const validResults = [
-        [19, 20, 42, 41, 21],
+    validResults = [
+        [41, 20, 42, 19, 21],
         [41, 20, 21, 19, 42],
+        [19, 20, 41, 42, 21],
         [19, 20, 41, 21, 42],
     ];
     assert.ok(validResults.some((result) => lodash.isEqual(result, actual)));
+
+    // result should not change if called twice
+    expected = lodash.clone(actual);
+    actual = MiltySliceGenerator.fixAdjAnomalies(actual);
+    assert.deepEqual(actual, expected);
 });

--- a/src/lib/shuffle.js
+++ b/src/lib/shuffle.js
@@ -9,7 +9,7 @@ class Shuffle {
     }
 
     // return one item randomly from an un-shuffled array
-    static drawRandom(a) {
+    static choice(a) {
         return a[Math.floor(Math.random() * a.length)];
     }
 }


### PR DESCRIPTION
@bradleysigma pointed out that the previous implementation had a bias towards certain anomaly positions (for ex 2,3 would get chosen 38% of the time)

Therefore, replace it with an implementation where we choose a random valid pair of positions for the anomalies (regardless of the original positions), and perform the required swaps to get there.