### PR TITLE
making attachments injectable

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -130,6 +130,9 @@ if (!world.__isMock) {
     console.log("Welcome to Twilight Imperium IV");
 }
 
+const {
+    AbstractPlanetAttachment,
+} = require("./objects/attachments/abstract-planet-attachment");
 const { Adjacency } = require("./lib/system/adjacency");
 const { Agenda } = require("./lib/agenda/agenda");
 const {
@@ -160,6 +163,7 @@ const { UnitPlastic } = require("./lib/unit/unit-plastic");
 // Register some functions in world to reduce require dependencies.
 world.TI4 = {
     // Export some modules (to work around require cycles, or for homebrew use).
+    AbstractPlanetAttachment,
     Adjacency,
     CardUtil,
     CommandToken,

--- a/src/global/planet-card-attachments.js
+++ b/src/global/planet-card-attachments.js
@@ -123,7 +123,7 @@ function addAttachmentsUI(card) {
         const isFaceUp = attachment.isAttachedFaceUp() || !attrs.faceDown;
         const faceAttrs = attrs[isFaceUp ? "faceUp" : "faceDown"];
         const image = faceAttrs.image;
-        const packageId = attachment.packageId || refPackageId;
+        const packageId = attrs.packageId || refPackageId;
         const tintColorHex = faceAttrs.tintColorHex || "#ffffff";
         const tintColor = ColorUtil.colorFromHex(tintColorHex);
         assert(image);

--- a/src/global/planet-card-attachments.js
+++ b/src/global/planet-card-attachments.js
@@ -32,7 +32,7 @@ const BOT = {
     numCols: 2,
 };
 
-function addImageCardFace(card, image, tintColor, index) {
+function addImageCardFace(card, packageId, image, tintColor, index) {
     assert(card instanceof Card);
     assert(typeof image === "string");
     assert(ColorUtil.isColor(tintColor));
@@ -60,7 +60,7 @@ function addImageCardFace(card, image, tintColor, index) {
     ui.rotation = new Rotator(180, 180, 0);
     ui.scale = 0.3;
     ui.widget = WidgetFactory.imageWidget()
-        .setImage(image, refPackageId)
+        .setImage(image, packageId)
         .setImageSize(50, 50)
         .setTintColor(tintColor);
     ui.zoomVisibility = UIZoomVisibility.Both;
@@ -68,7 +68,7 @@ function addImageCardFace(card, image, tintColor, index) {
     card.addUI(ui);
 }
 
-function addImageCardBack(card, image, tintColor, index) {
+function addImageCardBack(card, packageId, image, tintColor, index) {
     assert(card instanceof Card);
     assert(typeof image === "string");
     assert(ColorUtil.isColor(tintColor));
@@ -90,7 +90,7 @@ function addImageCardBack(card, image, tintColor, index) {
     ui.rotation = new Rotator(0, 0, 0);
     ui.scale = 0.3;
     ui.widget = WidgetFactory.imageWidget()
-        .setImage(image, refPackageId)
+        .setImage(image, packageId)
         .setImageSize(50, 50)
         .setTintColor(tintColor);
     ui.zoomVisibility = UIZoomVisibility.Both;
@@ -123,12 +123,13 @@ function addAttachmentsUI(card) {
         const isFaceUp = attachment.isAttachedFaceUp() || !attrs.faceDown;
         const faceAttrs = attrs[isFaceUp ? "faceUp" : "faceDown"];
         const image = faceAttrs.image;
+        const packageId = attachment.packageId || refPackageId;
         const tintColorHex = faceAttrs.tintColorHex || "#ffffff";
         const tintColor = ColorUtil.colorFromHex(tintColorHex);
         assert(image);
 
-        addImageCardFace(card, image, tintColor, index);
-        addImageCardBack(card, image, tintColor, index);
+        addImageCardFace(card, packageId, image, tintColor, index);
+        addImageCardBack(card, packageId, image, tintColor, index);
         attachmentNames.push(locale(attrs.localeName));
     });
     card.setDescription(attachmentNames.join("\n"));

--- a/src/lib/explore/explore.js
+++ b/src/lib/explore/explore.js
@@ -10,7 +10,7 @@ const { Plague } = require("../actions/plague");
 const { Spawn } = require("../../setup/spawn/spawn");
 const { UnitPlastic } = require("../unit/unit-plastic");
 const { WidgetFactory } = require("../ui/widget-factory");
-const { ATTACHMENTS } = require("../../objects/attachments/attachment.data");
+const { Attachment } = require("../../objects/attachments/attachment");
 const {
     Card,
     GameObject,
@@ -312,18 +312,13 @@ class Explore {
 
         // Is there an attachment?
         const nsid = ObjectNamespace.getNsid(card);
-        let attachmentData = false;
-        let tokenNsid = false;
-        for (const attachment of ATTACHMENTS) {
-            if (attachment.cardNsid === nsid) {
-                attachmentData = attachment;
-                tokenNsid = attachment.tokenNsid;
-                break;
-            }
-        }
-        if (!tokenNsid) {
+        let attachmentData = Attachment.getByCardNsidName(nsid);
+
+        if (!attachmentData) {
             return;
         }
+
+        const tokenNsid = attachmentData.tokenNsid;
 
         // Flip if planet has a tech.
         const tokenRot = new Rotator(rot.pitch, rot.yaw, 0);

--- a/src/lib/faction/faction.schema.js
+++ b/src/lib/faction/faction.schema.js
@@ -113,7 +113,7 @@ class FactionSchema {
     /**
      * Validate schema, returns error does not throw.
      *
-     * @param {object} system attributes
+     * @param {object} faction attributes
      * @param {function} onError - takes the error as single argument
      * @returns {boolean} true if valid
      */

--- a/src/lib/homebrew/homebrew.js
+++ b/src/lib/homebrew/homebrew.js
@@ -1,5 +1,6 @@
 const assert = require("../../wrapper/assert-wrapper");
 const locale = require("../locale");
+const { Attachment } = require("../../objects/attachments");
 const { Faction } = require("../faction/faction");
 const { Franken } = require("../draft/franken/franken");
 const { ReplaceObjects } = require("../../setup/spawn/replace-objects");
@@ -76,6 +77,11 @@ class Homebrew {
         if (table.unitModifiers) {
             for (const unitModifier of table.unitModifiers) {
                 UnitModifier.injectUnitModifier(unitModifier);
+            }
+        }
+        if (table.attachments) {
+            for (const attachment of table.attachments) {
+                Attachment.injectAttachment(attachment);
             }
         }
     }

--- a/src/lib/homebrew/homebrew.js
+++ b/src/lib/homebrew/homebrew.js
@@ -1,6 +1,6 @@
 const assert = require("../../wrapper/assert-wrapper");
 const locale = require("../locale");
-const { Attachment } = require("../../objects/attachments");
+const { Attachment } = require("../../objects/attachments/attachment");
 const { Faction } = require("../faction/faction");
 const { Franken } = require("../draft/franken/franken");
 const { ReplaceObjects } = require("../../setup/spawn/replace-objects");

--- a/src/objects/attachments/abstract-planet-attachment.js
+++ b/src/objects/attachments/abstract-planet-attachment.js
@@ -2,7 +2,7 @@ const assert = require("../../wrapper/assert-wrapper");
 const { AbstractSystemAttachment } = require("./abstract-system-attachment");
 const { Explore } = require("../../lib/explore/explore");
 const { ObjectNamespace } = require("../../lib/object-namespace");
-const { ATTACHMENTS } = require("./attachment.data");
+const { Attachment } = require("./attachment");
 const { GameObject, Vector } = require("../../wrapper/api");
 
 /**
@@ -10,7 +10,7 @@ const { GameObject, Vector } = require("../../wrapper/api");
  */
 class AbstractPlanetAttachment extends AbstractSystemAttachment {
     /**
-     * Set up a known attachment token (registered in attachment.data).
+     * Set up a known attachment token (registered in attachment.data and via homebrew.injectAttachment).
      *
      * @param {GameObject} gameObject
      * @returns {AbstractPlanetAttachment}
@@ -18,13 +18,8 @@ class AbstractPlanetAttachment extends AbstractSystemAttachment {
     static createForKnownAttachmentToken(gameObject) {
         assert(gameObject instanceof GameObject);
         const nsid = ObjectNamespace.getNsid(gameObject);
-        let attrs = false;
-        for (const candidate of ATTACHMENTS) {
-            if (nsid === candidate.tokenNsid) {
-                attrs = candidate;
-                break;
-            }
-        }
+        let attrs = Attachment.getByTokenNsidName(nsid);
+
         if (!attrs) {
             throw new Error(`KnownPlanetAttachment: no attrs for "${nsid}"`);
         }

--- a/src/objects/attachments/abstract-planet-attachment.js
+++ b/src/objects/attachments/abstract-planet-attachment.js
@@ -25,7 +25,7 @@ class AbstractPlanetAttachment extends AbstractSystemAttachment {
         }
         return new AbstractPlanetAttachment(
             gameObject,
-            attrs,
+            attrs.raw,
             attrs.localeName
         ).attachIfOnSystem();
     }

--- a/src/objects/attachments/attachment.js
+++ b/src/objects/attachments/attachment.js
@@ -70,8 +70,8 @@ class Attachment {
         return this._attachmentAttrs;
     }
 
-    get localName() {
-        return this._attachmentAttrs.localName;
+    get localeName() {
+        return this._attachmentAttrs.localeName;
     }
 
     get cardNsid() {

--- a/src/objects/attachments/attachment.js
+++ b/src/objects/attachments/attachment.js
@@ -1,0 +1,93 @@
+const assert = require("../../wrapper/assert-wrapper");
+const { AttachmentSchema } = require("./attachment.schema");
+const { ATTACHMENT_DATA } = require("./attachment.data");
+const { globalEvents, world } = require("../../wrapper/api");
+
+let _cardNsidNameToAttachment = undefined;
+let _tokenNsidNameToAttachment = undefined;
+
+globalEvents.TI4.onGameSetup.add(() => {
+    // setup may have changed PoK, Codex 3, etc.
+    _cardNsidNameToAttachment = undefined;
+    _tokenNsidNameToAttachment = undefined;
+});
+
+function _maybeInit() {
+    if (!_cardNsidNameToAttachment) {
+        _cardNsidNameToAttachment = {};
+        ATTACHMENT_DATA.forEach((attachmentAttrs) => {
+            const attachment = new Attachment(attachmentAttrs);
+            _cardNsidNameToAttachment[attachment.raw.cardNsid] = attachment;
+            _tokenNsidNameToAttachment[attachment.raw.tokenNsid] = attachment;
+        });
+    }
+}
+
+class Attachment {
+    /**
+     * Get all currently available attachments.
+     *
+     * @returns {Array.{Attachment}}
+     */
+    static getAllAttachments() {
+        _maybeInit();
+        return [...Object.values(_cardNsidNameToAttachment)];
+    }
+
+    static getByCardNsidName(nsidName) {
+        assert(typeof nsidName === "string");
+        _maybeInit();
+        return _cardNsidNameToAttachment[nsidName];
+    }
+
+    static getByTokenNsidName(nsidName) {
+        assert(typeof nsidName === "string");
+        _maybeInit();
+        return _tokenNsidNameToAttachment[nsidName];
+    }
+
+    static injectAttachment(attachmentAttrs) {
+        assert(attachmentAttrs);
+        AttachmentSchema.validate(attachmentAttrs, (err) => {
+            throw new Error(
+                `Attachment.injectAttachment schema error ${JSON.stringify(
+                    err
+                )}`
+            );
+        });
+        assert(Array.isArray(ATTACHMENT_DATA));
+        ATTACHMENT_DATA.push(attachmentAttrs);
+        _cardNsidNameToAttachment = undefined;
+        _tokenNsidNameToAttachment = undefined;
+    }
+
+    constructor(attachmentAttrs) {
+        this._attachmentAttrs = attachmentAttrs;
+    }
+
+    get raw() {
+        return this._attachmentAttrs;
+    }
+
+    get localName() {
+        return this._attachmentAttrs.localName;
+    }
+
+    get cardNsid() {
+        return this._attachmentAttrs.cardNsid;
+    }
+
+    get tokenNsid() {
+        return this._attachmentAttrs.tokenNsid;
+    }
+
+    get faceUp() {
+        return this._attachmentAttrs.faceUp;
+    }
+
+    get faceDown() {
+        return this._attachmentAttrs.faceDown;
+    }
+}
+
+module.exports = { Attachment };

--- a/src/objects/attachments/attachment.js
+++ b/src/objects/attachments/attachment.js
@@ -74,6 +74,10 @@ class Attachment {
         return this._attachmentAttrs.localeName;
     }
 
+    get packageId() {
+        return this._attachmentAttrs.packageId;
+    }
+
     get cardNsid() {
         return this._attachmentAttrs.cardNsid;
     }

--- a/src/objects/attachments/attachment.js
+++ b/src/objects/attachments/attachment.js
@@ -1,7 +1,7 @@
 const assert = require("../../wrapper/assert-wrapper");
 const { AttachmentSchema } = require("./attachment.schema");
-const { ATTACHMENT_DATA } = require("./attachment.data");
-const { globalEvents, world } = require("../../wrapper/api");
+const { ATTACHMENTS } = require("./attachment.data");
+const { globalEvents } = require("../../wrapper/api");
 
 let _cardNsidNameToAttachment = undefined;
 let _tokenNsidNameToAttachment = undefined;
@@ -15,7 +15,8 @@ globalEvents.TI4.onGameSetup.add(() => {
 function _maybeInit() {
     if (!_cardNsidNameToAttachment) {
         _cardNsidNameToAttachment = {};
-        ATTACHMENT_DATA.forEach((attachmentAttrs) => {
+        _tokenNsidNameToAttachment = {};
+        ATTACHMENTS.forEach((attachmentAttrs) => {
             const attachment = new Attachment(attachmentAttrs);
             _cardNsidNameToAttachment[attachment.raw.cardNsid] = attachment;
             _tokenNsidNameToAttachment[attachment.raw.tokenNsid] = attachment;
@@ -55,8 +56,8 @@ class Attachment {
                 )}`
             );
         });
-        assert(Array.isArray(ATTACHMENT_DATA));
-        ATTACHMENT_DATA.push(attachmentAttrs);
+        assert(Array.isArray(ATTACHMENTS));
+        ATTACHMENTS.push(attachmentAttrs);
         _cardNsidNameToAttachment = undefined;
         _tokenNsidNameToAttachment = undefined;
     }

--- a/src/objects/attachments/attachment.schema.js
+++ b/src/objects/attachments/attachment.schema.js
@@ -22,6 +22,7 @@ const ATTACHMENT_HELPER_SCHEMA = {
 const ATTACHMENT_SCHEMA = {
     type: "object",
     properties: {
+        packageId: { type: "strung" },
         localeName: { type: "string" },
         cardNsid: { type: "string" },
         tokenNsid: { type: "string" },

--- a/src/objects/attachments/attachment.schema.js
+++ b/src/objects/attachments/attachment.schema.js
@@ -22,7 +22,7 @@ const ATTACHMENT_HELPER_SCHEMA = {
 const ATTACHMENT_SCHEMA = {
     type: "object",
     properties: {
-        packageId: { type: "strung" },
+        packageId: { type: "string" },
         localeName: { type: "string" },
         cardNsid: { type: "string" },
         tokenNsid: { type: "string" },

--- a/src/objects/attachments/attachment.schema.js
+++ b/src/objects/attachments/attachment.schema.js
@@ -28,7 +28,7 @@ const ATTACHMENT_SCHEMA = {
         faceUp: ATTACHMENT_HELPER_SCHEMA,
         faceDown: ATTACHMENT_HELPER_SCHEMA,
     },
-    required: ["localeName", "cardNsid", "tokenNsid", "faceUp"],
+    required: ["localeName", "cardNsid", "tokenNsid"],
 };
 
 // Laxy instantiate on first use.

--- a/src/objects/attachments/attachment.schema.js
+++ b/src/objects/attachments/attachment.schema.js
@@ -24,10 +24,11 @@ const ATTACHMENT_SCHEMA = {
     properties: {
         localeName: { type: "string" },
         cardNsid: { type: "string" },
+        tokenNsid: { type: "string" },
         faceUp: ATTACHMENT_HELPER_SCHEMA,
         faceDown: ATTACHMENT_HELPER_SCHEMA,
     },
-    required: ["localeName"],
+    required: ["localeName", "cardNsid", "tokenNsid", "faceUp"],
 };
 
 // Laxy instantiate on first use.

--- a/src/objects/attachments/attachment.test.js
+++ b/src/objects/attachments/attachment.test.js
@@ -1,16 +1,16 @@
 const assert = require("assert");
 const { AttachmentSchema } = require("./attachment.schema");
-const { ATTACHMENTS } = require("./attachment.data");
+const { Attachment } = require("./attachment");
 const { ObjectNamespace } = require("../../lib/object-namespace");
 
 it("ATTACHMENTS attirbutes validate", () => {
-    ATTACHMENTS.forEach((attrs) => {
+    Attachment.getAllAttachments().forEach((attrs) => {
         assert(AttachmentSchema.validate(attrs));
     });
 });
 
 it("ATTACHMENTS nsids", () => {
-    ATTACHMENTS.forEach((attrs) => {
+    Attachment.getAllAttachments().forEach((attrs) => {
         if (attrs.cardNsid) {
             assert(ObjectNamespace.parseNsid(attrs.cardNsid));
         }

--- a/src/objects/attachments/attachment.test.js
+++ b/src/objects/attachments/attachment.test.js
@@ -1,3 +1,4 @@
+require("../../global"); // register world.TI4
 const assert = require("assert");
 const { AttachmentSchema } = require("./attachment.schema");
 const { Attachment } = require("./attachment");
@@ -5,7 +6,7 @@ const { ObjectNamespace } = require("../../lib/object-namespace");
 
 it("ATTACHMENTS attirbutes validate", () => {
     Attachment.getAllAttachments().forEach((attrs) => {
-        assert(AttachmentSchema.validate(attrs));
+        assert(AttachmentSchema.validate(attrs.raw));
     });
 });
 


### PR DESCRIPTION
To enable the abstract-planet-attachment in homebrew, the dataset currently directly derived from the attachment.data has to be extendable.
In addition, an internal mapping war introduced for easier consumption (getByCardNsidName / getByTokenNsidName).